### PR TITLE
test: add grunt-cli dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
-before_install:
-  - npm install grunt-cli -g
 node_js:
   - "0.12"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chai": "^3.4.1",
     "grunt": "^0.4.5",
     "grunt-babel": "^5.0.3",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.7.0",
     "grunt-contrib-jshint": "^0.11.1",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
This makes `npm test` not fail even if `grunt-cli` is not globally installed.