### PR TITLE
Add command line option for doing only specific transforms

### DIFF
--- a/bin/file.js
+++ b/bin/file.js
@@ -3,35 +3,33 @@ var _ = require('lodash');
 
 module.exports = function (program, file) {
   // Enable all transformers by default
-  var options = {
-    transformers: {
-      classes: true,
-      stringTemplates: true,
-      arrowFunctions: true,
-      let: true,
-      defaultArguments: true,
-      objectMethods: true
-    }
+  var transformers = {
+    classes: true,
+    stringTemplates: true,
+    arrowFunctions: true,
+    let: true,
+    defaultArguments: true,
+    objectMethods: true
   };
 
   // When --no-classes used, disable classes transformer
   if(! program.classes) {
-    options.transformers.classes = false;
+    transformers.classes = false;
   }
 
   // When --transformers used turn off everything besides the specified tranformers
   if (program.transformers) {
-    options.transformers = _.mapValues(options.transformers, _.constant(false));
+    transformers = _.mapValues(transformers, _.constant(false));
 
     program.transformers.forEach(function (name) {
-      if (!options.transformers.hasOwnProperty(name)) {
+      if (!transformers.hasOwnProperty(name)) {
         console.error("Unknown transformer '" + name + "'.");
       }
-      options.transformers[name] = true;
+      transformers[name] = true;
     });
   }
 
-  var transformer = new Transformer(options);
+  var transformer = new Transformer({transformers: transformers});
   transformer.readFile(file[0]);
   transformer.applyTransformations();
   transformer.writeFile(program.outFile);

--- a/bin/file.js
+++ b/bin/file.js
@@ -1,12 +1,34 @@
 var Transformer = require('./../lib/transformer');
+var _ = require('lodash');
 
 module.exports = function (program, file) {
+  // Enable all transformers by default
   var options = {
-    transformers: {}
+    transformers: {
+      classes: true,
+      stringTemplates: true,
+      arrowFunctions: true,
+      let: true,
+      defaultArguments: true,
+      objectMethods: true
+    }
   };
 
+  // When --no-classes used, disable classes transformer
   if(! program.classes) {
     options.transformers.classes = false;
+  }
+
+  // When --transformers used turn off everything besides the specified tranformers
+  if (program.transformers) {
+    options.transformers = _.mapValues(options.transformers, _.constant(false));
+
+    program.transformers.forEach(function (name) {
+      if (!options.transformers.hasOwnProperty(name)) {
+        console.error("Unknown transformer '" + name + "'.");
+      }
+      options.transformers[name] = true;
+    });
   }
 
   var transformer = new Transformer(options);

--- a/bin/index.js
+++ b/bin/index.js
@@ -6,8 +6,13 @@ var each = require("lodash/collection/each");
 var keys = require("lodash/object/keys");
 var pkg = require("../package.json");
 
+function list(val) {
+  return val.split(',');
+}
+
 program.option("-o, --out-file [out]", "Compile into a single file");
 program.option("--no-classes", "Don't convert function/prototypes into classes");
+program.option("-t, --transformers [a,b,c]", "Perform only specified transforms", list);
 program.description(pkg.description);
 program.version(pkg.version);
 program.usage("[options] <file>");

--- a/test/transformation/comments.js
+++ b/test/transformation/comments.js
@@ -1,7 +1,7 @@
 var expect = require('chai').expect;
 var
   Transformer = require('./../../lib/transformer'),
-  transformer = new Transformer({formatter: false});
+  transformer = new Transformer({formatter: false, transformers: {let: true}});
 
 function test(script) {
   transformer.read(script);


### PR DESCRIPTION
Current lebab only allows you to run all the available transforms. There's special-case option for disabling classes transform, but besides this you're forced to do all transforms.

But I'd like to pick some particular transform and run my code only through that. I can then migrate my codebase one transform at a time. When something goes wrong, I'll know the specific transform that is to be blamed.

So I added `--transformers` option which allows one to enable just one particular transform or several of them. When used, all other transforms that aren't specified will be disabled.

The first commit contains the core of this change. The other commits are just a bit of cleanup to simplify the whole transformers configuration pipeline.

Questions to consider before merging:

- What's the best name for this option? Maybe `--transforms` would be simpler to remember than `--transformers`.
- Do we want the shorthand `-t` for this?
- How to document the possible transformer names? They should be listed in `--help` output.
