### PR TITLE
Fix for member-assignment causing let to be used instead of const

### DIFF
--- a/src/transformation/let.js
+++ b/src/transformation/let.js
@@ -17,13 +17,13 @@ function replaceVar(node) {
     });
   }
 
-  if (node.type === 'AssignmentExpression') {
-    let left = node.left.name || node.left.property.name;
+  if (node.type === 'AssignmentExpression' && node.left.type === 'Identifier') {
+    let left = node.left.name;
 
     if (declarations[left]) {
       declarations[left].kind = 'let';
     }
-  } else if (node.type === 'UpdateExpression') {
+  } else if (node.type === 'UpdateExpression' && node.argument.type === 'Identifier') {
     let name = node.argument.name;
     if (declarations[name]) {
       declarations[name].kind = 'let';

--- a/test/transformation/let.js
+++ b/test/transformation/let.js
@@ -40,4 +40,15 @@ describe('Variable declaration var to let/const', function () {
     var script = 'var i = 0; i++;';
     expect(test(script)).to.equal('let i = 0; i++;');
   });
+
+  // Issue 53
+  it('should use const when similarly-named property is assigned to', function () {
+    var script = 'var a = 0; b.a += 1;';
+    expect(test(script)).to.equal('const a = 0; b.a += 1;');
+  });
+
+  it('should use const when similarly-named property is updated', function () {
+    var script = 'var a = 0; b.a++;';
+    expect(test(script)).to.equal('const a = 0; b.a++;');
+  });
 });


### PR DESCRIPTION
A simple fix - just check for the correct type.

Fixes #53