### PR TITLE
Implement object-shorthands transformation

### DIFF
--- a/bin/file.js
+++ b/bin/file.js
@@ -9,7 +9,8 @@ module.exports = function (program, file) {
     arrowFunctions: true,
     let: true,
     defaultArguments: true,
-    objectMethods: true
+    objectMethods: true,
+    objectShorthands: true,
   };
 
   // When --no-classes used, disable classes transformer

--- a/src/transformation/object-shorthands.js
+++ b/src/transformation/object-shorthands.js
@@ -1,0 +1,18 @@
+import estraverse from 'estraverse';
+
+export default
+  function (ast) {
+    estraverse.replace(ast, {
+      enter: propertyToShorthand
+    });
+  }
+
+function propertyToShorthand(node) {
+  if (node.type === 'Property' && equalIdentifiers(node.key, node.value)) {
+    node.shorthand = true;
+  }
+}
+
+function equalIdentifiers(a, b) {
+  return a.type === 'Identifier' && b.type === 'Identifier' && a.name === b.name;
+}

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -11,6 +11,7 @@ import arrowFunctionTransformation from './transformation/arrow-functions.js';
 import letTransformation from './transformation/let.js';
 import defaultArgsTransformation from './transformation/default-arguments.js';
 import objectMethodsTransformation from './transformation/object-methods.js';
+import objectShorthandsTransformation from './transformation/object-shorthands.js';
 
 const tranformersMap = {
   classes: classTransformation,
@@ -19,6 +20,7 @@ const tranformersMap = {
   let: letTransformation,
   defaultArguments: defaultArgsTransformation,
   objectMethods: objectMethodsTransformation,
+  objectShorthands: objectShorthandsTransformation,
 };
 
 export default

--- a/test/transformation/object-shorthands.js
+++ b/test/transformation/object-shorthands.js
@@ -1,0 +1,36 @@
+var expect = require('chai').expect;
+var Transformer = require('./../../lib/transformer');
+var objectShorthandsTransformation = require('./../../lib/transformation/object-shorthands');
+
+var transformer = new Transformer({});
+
+function test(script) {
+  transformer.read(script);
+  transformer.applyTransformation(objectShorthandsTransformation);
+  return transformer.out();
+}
+
+describe('Object shorthands', function () {
+
+  it('should convert matching key-value entries to shorthand notation', function () {
+    expect(test('({foo: foo})')).to.equal('({foo})');
+  });
+
+  it('should not convert non-matching key-value entries to shorthand notation', function () {
+    expect(test('({foo: bar})')).to.equal('({foo: bar})');
+  });
+
+  it('should not convert numeric properties to shorthands', function () {
+    expect(test('({10: 10})')).to.equal('({10: 10})');
+  });
+
+  // One might think we should also convert strings,
+  // but there might be some explicit reason why author chose
+  // to write his property names as strings,
+  // like when using Advanced compilation mode of Google Closure Compiler,
+  // where string keys signify that they should not be minified.
+  it('should not convert string properties to shorthands', function () {
+    expect(test('({"foo": foo})')).to.equal('({"foo": foo})');
+  });
+
+});


### PR DESCRIPTION
Converts `{foo: foo}` to `{foo}`.

Simple as that.