### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "estraverse": "^1.9.1",
     "esutils": "^1.1.6",
     "lodash": "^3.3.1",
-    "recast": "^0.10.39"
+    "recast": "^0.11.0"
   },
   "devDependencies": {
     "chai": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "coffee-script": "^1.9.1",
     "commander": "^2.6.0",
     "esformatter": "^0.6.1",
-    "estraverse": "^1.9.1",
+    "estraverse": "^4.1.1",
     "esutils": "^1.1.6",
     "lodash": "^3.3.1",
     "recast": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "recast": "^0.11.0"
   },
   "devDependencies": {
-    "chai": "^2.2.0",
+    "chai": "^3.4.1",
     "grunt": "^0.4.5",
     "grunt-babel": "^5.0.3",
     "grunt-contrib-clean": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "esformatter": "^0.6.1",
     "estraverse": "^4.1.1",
     "esutils": "^1.1.6",
-    "lodash": "^3.3.1",
+    "lodash": "^3.10.1",
     "recast": "^0.11.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "commander": "^2.6.0",
     "esformatter": "^0.6.1",
     "estraverse": "^4.1.1",
-    "esutils": "^1.1.6",
+    "esutils": "^2.0.2",
     "lodash": "^3.10.1",
     "recast": "^0.11.0"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/mohebifar/lebab",
   "dependencies": {
-    "babel": "^5.0.12",
+    "babel": "^5.8.34",
     "coffee-script": "^1.9.1",
     "commander": "^2.6.0",
     "esformatter": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "chai": "^2.2.0",
     "grunt": "^0.4.5",
-    "grunt-babel": "^4.0.0",
+    "grunt-babel": "^5.0.3",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.11.1",
     "grunt-contrib-watch": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chai": "^2.2.0",
     "grunt": "^0.4.5",
     "grunt-babel": "^5.0.3",
-    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-clean": "^0.7.0",
     "grunt-contrib-jshint": "^0.11.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-mocha-test": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "homepage": "https://github.com/mohebifar/lebab",
   "dependencies": {
     "babel": "^5.8.34",
-    "coffee-script": "^1.9.1",
-    "commander": "^2.6.0",
+    "coffee-script": "^1.10.0",
+    "commander": "^2.9.0",
     "esformatter": "^0.6.1",
     "estraverse": "^4.1.1",
     "esutils": "^2.0.2",
@@ -48,6 +48,6 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-mocha-test": "^0.12.7",
     "load-grunt-tasks": "^3.1.0",
-    "mocha": "^2.2.1"
+    "mocha": "^2.3.4"
   }
 }


### PR DESCRIPTION
Upgraded all libraries that were easily upgradable.

- new Recast eliminate lots of parsing problems reported in #62.
- new ESTraverse can now handle ES6 export syntax (a transform which I'd like to implement).

Did not upgrade ESFormatter as I suggested this dependency to be removed entirely in #71.

Some libraries will likely need more work for fully upgrading:

- Babel 6 has a whole new architecture.
- LoDash 4 has loads of breaking changes to be analyzed.
