### PR TITLE
Implement "use strict" removal

### DIFF
--- a/bin/file.js
+++ b/bin/file.js
@@ -11,6 +11,7 @@ module.exports = function (program, file) {
     defaultArguments: true,
     objectMethods: true,
     objectShorthands: true,
+    noStrict: true,
   };
 
   // When --no-classes used, disable classes transformer

--- a/src/transformation/no-strict.js
+++ b/src/transformation/no-strict.js
@@ -1,0 +1,19 @@
+import estraverse from 'estraverse';
+import typeChecker from '../utils/type-checker.js';
+
+export default
+  function (ast) {
+    estraverse.replace(ast, {
+      enter: removeUseStrict
+    });
+  }
+
+function removeUseStrict(node) {
+  if (node.type === 'ExpressionStatement' && isUseStrictString(node.expression)) {
+    this.remove();
+  }
+}
+
+function isUseStrictString(node) {
+  return typeChecker.isString(node) && node.value === 'use strict';
+}

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -12,6 +12,7 @@ import letTransformation from './transformation/let.js';
 import defaultArgsTransformation from './transformation/default-arguments.js';
 import objectMethodsTransformation from './transformation/object-methods.js';
 import objectShorthandsTransformation from './transformation/object-shorthands.js';
+import noStrictTransformation from './transformation/no-strict.js';
 
 const tranformersMap = {
   classes: classTransformation,
@@ -21,6 +22,7 @@ const tranformersMap = {
   defaultArguments: defaultArgsTransformation,
   objectMethods: objectMethodsTransformation,
   objectShorthands: objectShorthandsTransformation,
+  noStrict: noStrictTransformation,
 };
 
 export default

--- a/test/transformation/no-strict.js
+++ b/test/transformation/no-strict.js
@@ -1,0 +1,30 @@
+var expect = require('chai').expect;
+var Transformer = require('./../../lib/transformer');
+var noStrictTransformation = require('./../../lib/transformation/no-strict');
+
+var transformer = new Transformer({});
+
+function test(script) {
+  transformer.read(script);
+  transformer.applyTransformation(noStrictTransformation);
+  return transformer.out();
+}
+
+describe('Removal of "use strict"', function () {
+
+  it('should remove statement with "use strict" string', function () {
+    expect(test('"use strict";')).to.equal('');
+    expect(test("'use strict';")).to.equal('');
+  });
+
+  it('should remove the whole line where "use strict" used to be', function () {
+    expect(test('"use strict";\nfoo();')).to.equal('foo();');
+    expect(test('foo();\n"use strict";\nbar();')).to.equal('foo();\nbar();');
+  });
+
+  it('should keep "use strict" used inside other code', function () {
+    expect(test('x = "use strict";')).to.equal('x = "use strict";');
+    expect(test('foo("use strict");')).to.equal('foo("use strict");');
+  });
+
+});


### PR DESCRIPTION
ES6-specific code runs in strict mode and Babel also adds "use strict"
automatically to the generated code.  So there's rarely any need to
manually add a "use strict" directive.

This transform is also present in 5to6-codemod, which gave me the idea
of implementing it also in lebab:

- https://github.com/5to6/5to6-codemod