### PR TITLE
Various improvements to arrow-function transform

### DIFF
--- a/src/syntax/arrow-function-expression.js
+++ b/src/syntax/arrow-function-expression.js
@@ -29,8 +29,4 @@ class ArrowFunctionExpression extends BaseSyntax {
     this.id = null;
   }
 
-  appendToBody(statement) {
-    this.body.appendToBody(statement);
-  }
-
 }

--- a/src/syntax/arrow-function-expression.js
+++ b/src/syntax/arrow-function-expression.js
@@ -1,5 +1,4 @@
 import BaseSyntax from './base.js';
-import BlockStatement from './block-statement.js';
 
 /**
  * The class to define the ArrowFunctionExpression syntax
@@ -13,14 +12,19 @@ class ArrowFunctionExpression extends BaseSyntax {
    * The constructor of ArrowFunctionExpression
    *
    * @constructor
+   * @param {Object} cfg
+   * @param {Node} cfg.body
+   * @param {Node[]} cfg.params
+   * @param {Node[]} cfg.defaults
+   * @param {Node|null} cfg.rest
    */
-  constructor() {
+  constructor({body, params, defaults, rest}) {
     super('ArrowFunctionExpression');
 
-    this.body = new BlockStatement();
-    this.params = [];
-    this.defaults = [];
-    this.rest = null;
+    this.body = body;
+    this.params = params;
+    this.defaults = defaults;
+    this.rest = rest;
     this.generator = false;
     this.id = null;
   }

--- a/src/syntax/arrow-function-expression.js
+++ b/src/syntax/arrow-function-expression.js
@@ -2,15 +2,15 @@ import BaseSyntax from './base.js';
 import BlockStatement from './block-statement.js';
 
 /**
- * The class to define the ArrowExpression syntax
+ * The class to define the ArrowFunctionExpression syntax
  *
- * @class ArrowExpression
+ * @class ArrowFunctionExpression
  */
 export default
-class ArrowExpression extends BaseSyntax {
+class ArrowFunctionExpression extends BaseSyntax {
 
   /**
-   * The constructor of ArrowExpression
+   * The constructor of ArrowFunctionExpression
    *
    * @constructor
    */

--- a/src/syntax/block-statement.js
+++ b/src/syntax/block-statement.js
@@ -18,10 +18,6 @@ class BlockStatement extends BaseSyntax {
     this.body = [];
   }
 
-  appendToBody(statement) {
-    this.body.push(statement);
-  }
-
   /**
    * Check if an object is representing a BlockStatement
    *

--- a/src/syntax/function-expression.js
+++ b/src/syntax/function-expression.js
@@ -25,8 +25,4 @@ class FunctionExpression extends BaseSyntax {
     this.id = null;
   }
 
-  appendToBody(statement) {
-    this.body.appendToBody(statement);
-  }
-
 }

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -25,7 +25,7 @@ function callBackToArrow(node) {
 }
 
 function hasThis(ast) {
-  var thisFound = false;
+  let thisFound = false;
 
   estraverse.traverse(ast, {
     enter: function (node) {

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -10,13 +10,12 @@ export default
 
 function callBackToArrow(node) {
 
-  if (node.type === 'FunctionExpression' && !node.id && !hasThis(node.body)) {
+  if (node.type === 'FunctionExpression' && !node.id && !node.generator && !hasThis(node.body)) {
     let arrow = new ArrowExpression();
     arrow.body = extractArrowBody(node.body);
     arrow.params = node.params;
     arrow.rest = node.rest;
     arrow.defaults = node.defaults;
-    arrow.generator = node.generator;
 
     return arrow;
   }

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -8,9 +8,9 @@ export default
     });
   }
 
-function callBackToArrow(node, parent) {
+function callBackToArrow(node) {
 
-  if (node.type === 'FunctionExpression' && parent.type === 'CallExpression' && !hasThis(node.body)) {
+  if (node.type === 'FunctionExpression' && !hasThis(node.body)) {
     let arrow = new ArrowExpression();
     arrow.body = node.body;
     arrow.params = node.params;

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -23,7 +23,8 @@ function isFunctionConvertableToArrow(node) {
   return node.type === 'FunctionExpression' &&
     !node.id &&
     !node.generator &&
-    !hasThis(node.body);
+    !hasThis(node.body) &&
+    !hasArguments(node.body);
 }
 
 function hasThis(ast) {
@@ -42,6 +43,24 @@ function hasThis(ast) {
   });
 
   return thisFound;
+}
+
+function hasArguments(ast) {
+  let argumentsFound = false;
+
+  estraverse.traverse(ast, {
+    enter: function (node) {
+      if (node.type === 'Identifier' && node.name === 'arguments') {
+        argumentsFound = true;
+        this.break();
+      }
+      if (node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration') {
+        this.skip();
+      }
+    }
+  });
+
+  return argumentsFound;
 }
 
 function extractArrowBody(block) {

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -9,8 +9,7 @@ export default
   }
 
 function callBackToArrow(node) {
-
-  if (node.type === 'FunctionExpression' && !node.id && !node.generator && !hasThis(node.body)) {
+  if (isFunctionConvertableToArrow(node)) {
     let arrow = new ArrowExpression();
     arrow.body = extractArrowBody(node.body);
     arrow.params = node.params;
@@ -19,7 +18,13 @@ function callBackToArrow(node) {
 
     return arrow;
   }
+}
 
+function isFunctionConvertableToArrow(node) {
+  return node.type === 'FunctionExpression' &&
+    !node.id &&
+    !node.generator &&
+    !hasThis(node.body);
 }
 
 function hasThis(ast) {

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -10,13 +10,12 @@ export default
 
 function callBackToArrow(node) {
   if (isFunctionConvertableToArrow(node)) {
-    let arrow = new ArrowFunctionExpression();
-    arrow.body = extractArrowBody(node.body);
-    arrow.params = node.params;
-    arrow.rest = node.rest;
-    arrow.defaults = node.defaults;
-
-    return arrow;
+    return new ArrowFunctionExpression({
+      body: extractArrowBody(node.body),
+      params: node.params,
+      defaults: node.defaults,
+      rest: node.rest,
+    });
   }
 }
 

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -10,14 +10,13 @@ export default
 
 function callBackToArrow(node) {
 
-  if (node.type === 'FunctionExpression' && !hasThis(node.body)) {
+  if (node.type === 'FunctionExpression' && !node.id && !hasThis(node.body)) {
     let arrow = new ArrowExpression();
     arrow.body = extractArrowBody(node.body);
     arrow.params = node.params;
     arrow.rest = node.rest;
     arrow.defaults = node.defaults;
     arrow.generator = node.generator;
-    arrow.id = node.id;
 
     return arrow;
   }

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -1,5 +1,5 @@
 import estraverse from 'estraverse';
-import ArrowExpression from './../syntax/arrow-expression.js';
+import ArrowFunctionExpression from './../syntax/arrow-function-expression.js';
 
 export default
   function (ast) {
@@ -10,7 +10,7 @@ export default
 
 function callBackToArrow(node) {
   if (isFunctionConvertableToArrow(node)) {
-    let arrow = new ArrowExpression();
+    let arrow = new ArrowFunctionExpression();
     arrow.body = extractArrowBody(node.body);
     arrow.params = node.params;
     arrow.rest = node.rest;

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -28,30 +28,22 @@ function isFunctionConvertableToArrow(node) {
 }
 
 function hasThis(ast) {
-  let thisFound = false;
-
-  estraverse.traverse(ast, {
-    enter: function (node) {
-      if (node.type === 'ThisExpression') {
-        thisFound = true;
-        this.break();
-      }
-      if (node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration') {
-        this.skip();
-      }
-    }
-  });
-
-  return thisFound;
+  return hasInFunctionBody(ast, node => node.type === 'ThisExpression');
 }
 
 function hasArguments(ast) {
-  let argumentsFound = false;
+  return hasInFunctionBody(ast, node => node.type === 'Identifier' && node.name === 'arguments');
+}
+
+// Returns true when predicate matches any node in given function body,
+// excluding any nested functions
+function hasInFunctionBody(ast, predicate) {
+  let found = false;
 
   estraverse.traverse(ast, {
     enter: function (node) {
-      if (node.type === 'Identifier' && node.name === 'arguments') {
-        argumentsFound = true;
+      if (predicate(node)) {
+        found = true;
         this.break();
       }
       if (node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration') {
@@ -60,7 +52,7 @@ function hasArguments(ast) {
     }
   });
 
-  return argumentsFound;
+  return found;
 }
 
 function extractArrowBody(block) {

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -12,7 +12,7 @@ function callBackToArrow(node) {
 
   if (node.type === 'FunctionExpression' && !hasThis(node.body)) {
     let arrow = new ArrowExpression();
-    arrow.body = node.body;
+    arrow.body = extractArrowBody(node.body);
     arrow.params = node.params;
     arrow.rest = node.rest;
     arrow.defaults = node.defaults;
@@ -40,4 +40,12 @@ function hasThis(ast) {
   });
 
   return thisFound;
+}
+
+function extractArrowBody(block) {
+  if (block.body[0] && block.body[0].type === 'ReturnStatement') {
+    return block.body[0].argument;
+  } else {
+    return block;
+  }
 }

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -24,7 +24,7 @@ describe('Callback to Arrow transformation', function () {
     expect(test(script)).to.equal('a(b => { return b; });');
   });
 
-  it('should convert callbacks with a single argument', function () {
+  it('should convert callbacks with multiple arguments', function () {
     var script = 'a(function(b, c) { return b; });';
 
     expect(test(script)).to.equal('a((b, c) => { return b; });');

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -58,6 +58,18 @@ describe('Callback to Arrow transformation', function () {
     expect(test(script)).to.equal('a(() => function() { this; });');
   });
 
+  it('should preserve default parameters', function () {
+    var script = 'foo(function (a=1, b=2, c) { });';
+
+    expect(test(script)).to.equal('foo((a=1, b=2, c) => { });');
+  });
+
+  it('should preserve rest parameters', function () {
+    var script = 'foo(function (x, ...xs) { });';
+
+    expect(test(script)).to.equal('foo((x, ...xs) => { });');
+  });
+
 
   it('should not convert function declarations', function () {
     expectNoChange('function foo() {};');

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -58,6 +58,12 @@ describe('Callback to Arrow transformation', function () {
     expect(test(script)).to.equal('a(() => function() { this; });');
   });
 
+  it('should convert functions using `arguments` inside a nested function', function () {
+    var script = 'a(function () { return function() { arguments; }; });';
+
+    expect(test(script)).to.equal('a(() => function() { arguments; });');
+  });
+
   it('should preserve default parameters', function () {
     var script = 'foo(function (a=1, b=2, c) { });';
 
@@ -92,6 +98,14 @@ describe('Callback to Arrow transformation', function () {
     expectNoChange('a(function () { return this; });');
     expectNoChange('a(function () { if (x) foo(this); });');
     expectNoChange('a(function () { for (x of foo) { bar(this); } });');
+  });
+
+  it('should not convert functions using `arguments`', function () {
+    expectNoChange('a(function () { arguments; });');
+    expectNoChange('a(function () { foo(arguments); });');
+    expectNoChange('a(function () { return arguments[0] + 1; });');
+    expectNoChange('a(function () { return Array.slice.apply(arguments); });');
+    expectNoChange('a(function () { if (x) foo(arguments); });');
   });
 
 });

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -34,13 +34,26 @@ describe('Callback to Arrow transformation', function () {
     expect(test(script)).to.equal('a((b, c) => { return b; });');
   });
 
+  it('should convert functions using `this` keyword inside a nested function', function () {
+    var script = 'a(function () { return function() { this; }; });';
+
+    expect(test(script)).to.equal('a(() => { return function() { this; }; });');
+  });
+
 
   it('should not convert other forms of functions', function () {
     expectNoChange('var x = function () {};');
   });
 
   it('should not convert functions using `this` keyword', function () {
-    expectNoChange('a(function (b) { this.x = 2; });');
+    expectNoChange('a(function () { this; });');
+    expectNoChange('a(function () { this.x = 2; });');
+    expectNoChange('a(function () { this.bar(); });');
+    expectNoChange('a(function () { foo(this); });');
+    expectNoChange('a(function () { foo(this.bar); });');
+    expectNoChange('a(function () { return this; });');
+    expectNoChange('a(function () { if (x) foo(this); });');
+    expectNoChange('a(function () { for (x of foo) { bar(this); } });');
   });
 
 });

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -34,6 +34,24 @@ describe('Callback to Arrow transformation', function () {
     expect(test(script)).to.equal('a((b, c) => { return b; });');
   });
 
+  it('should convert function assignment', function () {
+    var script = 'x = function () { foo(); };';
+
+    expect(test(script)).to.equal('x = () => { foo(); };');
+  });
+
+  it('should convert immediate function invocation', function () {
+    var script = '(function () { foo(); }());';
+
+    expect(test(script)).to.equal('((() => { foo(); })());');
+  });
+
+  it('should convert returning of a function', function () {
+    var script = 'function foo () { return function() { foo(); }; }';
+
+    expect(test(script)).to.equal('function foo () { return () => { foo(); }; }');
+  });
+
   it('should convert functions using `this` keyword inside a nested function', function () {
     var script = 'a(function () { return function() { this; }; });';
 
@@ -41,8 +59,8 @@ describe('Callback to Arrow transformation', function () {
   });
 
 
-  it('should not convert other forms of functions', function () {
-    expectNoChange('var x = function () {};');
+  it('should not convert function declarations', function () {
+    expectNoChange('function foo() {};');
   });
 
   it('should not convert functions using `this` keyword', function () {

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -63,6 +63,10 @@ describe('Callback to Arrow transformation', function () {
     expectNoChange('function foo() {};');
   });
 
+  it('should not convert named function expressions', function () {
+    expectNoChange('f = function fact(n) { return n * fact(n-1); };');
+  });
+
   it('should not convert functions using `this` keyword', function () {
     expectNoChange('a(function () { this; });');
     expectNoChange('a(function () { this.x = 2; });');

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -79,6 +79,10 @@ describe('Callback to Arrow transformation', function () {
     expectNoChange('f = function fact(n) { return n * fact(n-1); };');
   });
 
+  it('should not convert generators', function () {
+    expectNoChange('f = function* (n) { };');
+  });
+
   it('should not convert functions using `this` keyword', function () {
     expectNoChange('a(function () { this; });');
     expectNoChange('a(function () { this.x = 2; });');

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -10,6 +10,10 @@ function test(script) {
   return transformer.out();
 }
 
+function expectNoChange(script) {
+  expect(test(script)).to.equal(script);
+}
+
 describe('Callback to Arrow transformation', function () {
 
   it('should convert simple callbacks', function () {
@@ -31,16 +35,12 @@ describe('Callback to Arrow transformation', function () {
   });
 
 
-  it('shouldn\'t convert other forms of functions', function () {
-    var script = 'var x = function () {};';
-
-    expect(test(script)).to.equal(script);
+  it('should not convert other forms of functions', function () {
+    expectNoChange('var x = function () {};');
   });
 
-  it('shouldn\'t convert functions using `this` keyword', function () {
-    var script = 'a(function (b) { this.x = 2; });';
-
-    expect(test(script)).to.equal(script);
+  it('should not convert functions using `this` keyword', function () {
+    expectNoChange('a(function (b) { this.x = 2; });');
   });
 
 });

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -19,19 +19,19 @@ describe('Callback to Arrow transformation', function () {
   it('should convert simple callbacks', function () {
     var script = 'setTimeout(function() { return 2; });';
 
-    expect(test(script)).to.equal('setTimeout(() => { return 2; });');
+    expect(test(script)).to.equal('setTimeout(() => 2);');
   });
 
   it('should convert callbacks with a single argument', function () {
     var script = 'a(function(b) { return b; });';
 
-    expect(test(script)).to.equal('a(b => { return b; });');
+    expect(test(script)).to.equal('a(b => b);');
   });
 
   it('should convert callbacks with multiple arguments', function () {
     var script = 'a(function(b, c) { return b; });';
 
-    expect(test(script)).to.equal('a((b, c) => { return b; });');
+    expect(test(script)).to.equal('a((b, c) => b);');
   });
 
   it('should convert function assignment', function () {
@@ -55,7 +55,7 @@ describe('Callback to Arrow transformation', function () {
   it('should convert functions using `this` keyword inside a nested function', function () {
     var script = 'a(function () { return function() { this; }; });';
 
-    expect(test(script)).to.equal('a(() => { return function() { this; }; });');
+    expect(test(script)).to.equal('a(() => function() { this; });');
   });
 
 


### PR DESCRIPTION
Fixes issues #50, #51 and #52. Properly handling the presence of `this` and `arguments`, and targeting all function expressions.

Additionally:

- convert function expressions with single return statement to short form.
- don't convert named function expressions.
- don't convert generators.

In the end also refactored the arrow-function transform and syntax node code a bit.