### PR TITLE
Transform for CommonJS module definitions

### DIFF
--- a/bin/file.js
+++ b/bin/file.js
@@ -12,6 +12,8 @@ module.exports = function (program, file) {
     objectMethods: true,
     objectShorthands: true,
     noStrict: true,
+    importCommonjs: false,
+    exportCommonjs: false,
   };
 
   // When --no-classes used, disable classes transformer
@@ -29,6 +31,15 @@ module.exports = function (program, file) {
       }
       transformers[name] = true;
     });
+  }
+
+  // When --module=commonjs used, enable CommonJS Transformers
+  if (program.module === 'commonjs') {
+    transformers.importCommonjs = true;
+    transformers.exportCommonjs = true;
+  }
+  else if (program.module) {
+    console.error("Unsupported module system '" + program.module + "'.");
   }
 
   var transformer = new Transformer({transformers: transformers});

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,6 +13,7 @@ function list(val) {
 program.option("-o, --out-file [out]", "Compile into a single file");
 program.option("--no-classes", "Don't convert function/prototypes into classes");
 program.option("-t, --transformers [a,b,c]", "Perform only specified transforms", list);
+program.option("--module [commonjs]", "Transform CommonJS module syntax");
 program.description(pkg.description);
 program.version(pkg.version);
 program.usage("[options] <file>");

--- a/src/syntax/export-default-declaration.js
+++ b/src/syntax/export-default-declaration.js
@@ -1,0 +1,19 @@
+import BaseSyntax from './base.js';
+
+/**
+ * The class to define the ExportDefaultDeclaration syntax
+ *
+ * @class ImportDeclaration
+ */
+export default
+class ExportDefaultDeclaration extends BaseSyntax {
+
+  /**
+   * @param {Node} declaration
+   */
+  constructor(declaration) {
+    super('ExportDefaultDeclaration');
+    this.declaration = declaration;
+  }
+
+}

--- a/src/syntax/import-declaration.js
+++ b/src/syntax/import-declaration.js
@@ -1,0 +1,24 @@
+import BaseSyntax from './base.js';
+import ImportDefaultSpecifier from './import-default-specifier.js';
+
+/**
+ * The class to define the ImportDeclaration syntax
+ *
+ * @class ImportDeclaration
+ */
+export default
+class ImportDeclaration extends BaseSyntax {
+
+  /**
+   * @param {Identifier} identifier  Variable for default import
+   * @param {Literal} source String literal containing library path
+   */
+  constructor(identifier, source) {
+    super('ImportDeclaration');
+    this.specifiers = [
+      new ImportDefaultSpecifier(identifier)
+    ];
+    this.source = source;
+  }
+
+}

--- a/src/syntax/import-default-specifier.js
+++ b/src/syntax/import-default-specifier.js
@@ -6,7 +6,7 @@ import BaseSyntax from './base.js';
  * @class ImportDefaultSpecifier
  */
 export default
-class CallExpression extends BaseSyntax {
+class ImportDefaultSpecifier extends BaseSyntax {
 
   /**
    * @param {Identifier} local  The local variable where to import

--- a/src/syntax/import-default-specifier.js
+++ b/src/syntax/import-default-specifier.js
@@ -1,0 +1,19 @@
+import BaseSyntax from './base.js';
+
+/**
+ * The class to define the ImportDefaultSpecifier syntax
+ *
+ * @class ImportDefaultSpecifier
+ */
+export default
+class CallExpression extends BaseSyntax {
+
+  /**
+   * @param {Identifier} local  The local variable where to import
+   */
+  constructor(local) {
+    super('ImportDefaultSpecifier');
+    this.local = local;
+  }
+
+}

--- a/src/syntax/variable-declaration.js
+++ b/src/syntax/variable-declaration.js
@@ -1,0 +1,23 @@
+import BaseSyntax from './base.js';
+
+/**
+ * The class to define the VariableDeclaration syntax
+ *
+ * @class VariableDeclaration
+ */
+export default
+class VariableDeclaration extends BaseSyntax {
+
+  /**
+   * The constructor of VariableDeclaration
+   *
+   * @param {String} kind
+   * @param {VariableDeclarator[]} declarations
+   */
+  constructor(kind, declarations) {
+    super('VariableDeclaration');
+
+    this.kind = kind;
+    this.declarations = declarations;
+  }
+}

--- a/src/transformation/export-commonjs.js
+++ b/src/transformation/export-commonjs.js
@@ -8,8 +8,8 @@ export default
     });
   }
 
-function traverse(node) {
-  if (isModuleExportsAssignment(node)) {
+function traverse(node, parent) {
+  if (isModuleExportsAssignment(node) && parent.type === 'Program') {
     return new ExportDefaultDeclaration(node.expression.right);
   }
 }

--- a/src/transformation/export-commonjs.js
+++ b/src/transformation/export-commonjs.js
@@ -1,0 +1,33 @@
+import estraverse from 'estraverse';
+import ExportDefaultDeclaration from '../syntax/export-default-declaration.js';
+
+export default
+  function (ast) {
+    estraverse.replace(ast, {
+      enter: traverse
+    });
+  }
+
+function traverse(node) {
+  if (isModuleExportsAssignment(node)) {
+    return new ExportDefaultDeclaration(node.expression.right);
+  }
+}
+
+function isModuleExportsAssignment(node) {
+  return node.type === 'ExpressionStatement' &&
+    node.expression.type === 'AssignmentExpression' &&
+    node.expression.operator === '=' &&
+    isModuleExportsMemberExpression(node.expression.left);
+}
+
+function isModuleExportsMemberExpression(node) {
+  return node.type === 'MemberExpression' &&
+    node.computed === false &&
+    isIdentifier(node.object, 'module') &&
+    isIdentifier(node.property, 'exports');
+}
+
+function isIdentifier(node, name) {
+  return node.type === 'Identifier' && node.name === name;
+}

--- a/src/transformation/import-commonjs.js
+++ b/src/transformation/import-commonjs.js
@@ -11,7 +11,7 @@ export default
   }
 
 function traverse(node, parent) {
-  if (isVarWithRequireCalls(node)) {
+  if (isVarWithRequireCalls(node) && parent.type === 'Program') {
     const declarations = node.declarations.map(dec => {
       if (isRequireDeclaration(dec)) {
         return new ImportDeclaration(dec.id, dec.init.arguments[0]);

--- a/src/transformation/import-commonjs.js
+++ b/src/transformation/import-commonjs.js
@@ -1,0 +1,44 @@
+import estraverse from 'estraverse';
+import typeChecker from '../utils/type-checker.js';
+import ImportDeclaration from '../syntax/import-declaration.js';
+import VariableDeclaration from '../syntax/variable-declaration.js';
+
+export default
+  function (ast) {
+    estraverse.replace(ast, {
+      enter: traverse
+    });
+  }
+
+function traverse(node, parent) {
+  if (isVarWithRequireCalls(node)) {
+    const declarations = node.declarations.map(dec => {
+      if (isRequireDeclaration(dec)) {
+        return new ImportDeclaration(dec.id, dec.init.arguments[0]);
+      } else {
+        return new VariableDeclaration(node.kind, [dec]);
+      }
+    });
+
+    parent.body.splice(parent.body.indexOf(node), 1, ...declarations);
+  }
+}
+
+function isVarWithRequireCalls(node) {
+  return node.type === 'VariableDeclaration' &&
+    node.declarations.some(isRequireDeclaration);
+}
+
+function isRequireDeclaration(node) {
+  return node.id.type === 'Identifier' &&
+    node.init &&
+    isRequireCall(node.init);
+}
+
+function isRequireCall(node) {
+  return node.type === 'CallExpression' &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'require' &&
+    node.arguments.length === 1 &&
+    typeChecker.isString(node.arguments[0]);
+}

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -13,6 +13,8 @@ import defaultArgsTransformation from './transformation/default-arguments.js';
 import objectMethodsTransformation from './transformation/object-methods.js';
 import objectShorthandsTransformation from './transformation/object-shorthands.js';
 import noStrictTransformation from './transformation/no-strict.js';
+import importCommonjsTransformation from './transformation/import-commonjs.js';
+import exportCommonjsTransformation from './transformation/export-commonjs.js';
 
 const tranformersMap = {
   classes: classTransformation,
@@ -23,6 +25,8 @@ const tranformersMap = {
   objectMethods: objectMethodsTransformation,
   objectShorthands: objectShorthandsTransformation,
   noStrict: noStrictTransformation,
+  importCommonjs: importCommonjsTransformation,
+  exportCommonjs: exportCommonjsTransformation,
 };
 
 export default

--- a/test/transformation/export-commonjs.js
+++ b/test/transformation/export-commonjs.js
@@ -1,0 +1,43 @@
+var expect = require('chai').expect;
+var Transformer = require('./../../lib/transformer');
+var exportCommonJsTransformation = require('./../../lib/transformation/export-commonjs');
+
+var transformer = new Transformer({});
+
+function test(script) {
+  transformer.read(script);
+  transformer.applyTransformation(exportCommonJsTransformation);
+  return transformer.out();
+}
+
+function expectNoChange(script) {
+  expect(test(script)).to.equal(script);
+}
+
+describe('Export CommonJS', function () {
+
+  it('should convert module.exports assignment to default export', function () {
+    expect(test('module.exports = 123;')).to.equal('export default 123;');
+    expect(test('module.exports = function() {};')).to.equal('export default function() {};');
+    expect(test('module.exports = x => x;')).to.equal('export default x => x;');
+    expect(test('module.exports = class {};')).to.equal('export default class {};');
+  });
+
+  it('should not convert assignment to exports', function () {
+    expectNoChange('exports = function() {};');
+  });
+
+  it('should not convert weird assignment to module.exports', function () {
+    expectNoChange('module.exports += function() {};');
+    expectNoChange('module.exports -= function() {};');
+    expectNoChange('module.exports *= function() {};');
+    expectNoChange('module.exports /= function() {};');
+  });
+
+  // A pretty weird thing to do...
+  // shouldn't bother supporting it.
+  it('should not convert assignment to module["exports"]', function () {
+    expectNoChange('module["exports"] = function() {};');
+  });
+
+});

--- a/test/transformation/export-commonjs.js
+++ b/test/transformation/export-commonjs.js
@@ -40,4 +40,12 @@ describe('Export CommonJS', function () {
     expectNoChange('module["exports"] = function() {};');
   });
 
+  it('should ignore module.exports inside statements', function () {
+    expectNoChange(
+      'if (true) {\n' +
+      '  module.exports = function() {};\n' +
+      '}'
+    );
+  });
+
 });

--- a/test/transformation/import-commonjs.js
+++ b/test/transformation/import-commonjs.js
@@ -1,0 +1,99 @@
+var expect = require('chai').expect;
+var Transformer = require('./../../lib/transformer');
+var importCommonJsTransformation = require('./../../lib/transformation/import-commonjs');
+
+var transformer = new Transformer({});
+
+function test(script) {
+  transformer.read(script);
+  transformer.applyTransformation(importCommonJsTransformation);
+  return transformer.out();
+}
+
+function expectNoChange(script) {
+  expect(test(script)).to.equal(script);
+}
+
+describe('Import CommonJS', function () {
+
+  it('should convert basic var/let/const with require()', function () {
+    expect(test('var   foo = require("foo");')).to.equal('import foo from "foo";');
+    expect(test('const foo = require("foo");')).to.equal('import foo from "foo";');
+    expect(test('let   foo = require("foo");')).to.equal('import foo from "foo";');
+  });
+
+  it('should do nothing with var that contains no require()', function () {
+    expectNoChange('var foo = "bar";');
+    expectNoChange('var foo;');
+  });
+
+  it('should do nothing with require() that does not have a single string argument', function () {
+    expectNoChange('var foo = require();');
+    expectNoChange('var foo = require("foo", {});');
+    expectNoChange('var foo = require(bar);');
+    expectNoChange('var foo = require(123);');
+  });
+
+  it('should convert var with multiple require() calls', function () {
+    expect(test(
+      'var foo = require("foo"), bar = require("bar");'
+    )).to.equal(
+      'import foo from "foo";\n' +
+      'import bar from "bar";'
+    );
+  });
+
+  it('should convert var/let/const with intermixed require() calls and normal initializations', function () {
+    expect(test(
+      'var foo = require("foo"), bar = 15;'
+    )).to.equal(
+      'import foo from "foo";\n' +
+      'var bar = 15;'
+    );
+
+    expect(test(
+      'let abc, foo = require("foo")'
+    )).to.equal(
+      'let abc;\n' +
+      'import foo from "foo";'
+    );
+
+    expect(test(
+      'const greeting = "hello", foo = require("foo");'
+    )).to.equal(
+      'const greeting = "hello";\n' +
+      'import foo from "foo";'
+    );
+  });
+
+  // It would be nice to preserve the combined declarations,
+  // but this kind of intermixed vars should really be a rare edge case.
+  it('does not need to preserve combined variable declarations', function () {
+    expect(test(
+      'var foo = require("foo"), bar = 1, baz = 2;'
+    )).to.equal(
+      'import foo from "foo";\n' +
+      'var bar = 1;\n' +
+      'var baz = 2;'
+    );
+  });
+
+  // Not yet supported things...
+
+  it('should not convert assignment of require() call', function () {
+    expectNoChange('foo = require("foo");');
+  });
+
+  it('should not convert unassigned require() call', function () {
+    expectNoChange('require("foo");');
+  });
+
+  it('should not convert require() with property extraction', function () {
+    expectNoChange('var foo = require("foolib").foo;');
+  });
+
+  it('should not convert require() with object destruction', function () {
+    expectNoChange('var {foo} = require("foolib");');
+  });
+
+});

--- a/test/transformation/import-commonjs.js
+++ b/test/transformation/import-commonjs.js
@@ -78,6 +78,14 @@ describe('Import CommonJS', function () {
     );
   });
 
+  it('should ignore require calls inside statements', function () {
+    expectNoChange(
+      'if (true) {\n' +
+      '  var foo = require("foo");\n' +
+      '}'
+    );
+  });
+
   // Not yet supported things...
 
   it('should not convert assignment of require() call', function () {


### PR DESCRIPTION
Support default import and export.

Not enabling this by default but instead it needs to be explicitly enabled through `--module commonjs` switch.

There are still some deficiencies in this implementation resulting from the fact that import declarations work like `const` declaration not like `var`. This means:

- they can't be re-assigned.
- they can't be referenced before being declared.

These things are currently not checked for. Those checks however are very similar to what we want to do for `let/const` transform. Maybe we could re-purpose the logic for let/const (when it gets fixed) to also cover the import case. Alternatively we could first perform transform to `let/const` and then only transform `const` declarations to imports.

This should mostly solve #12