### PR TITLE
Track variable scope for when choosing let v/s const

### DIFF
--- a/src/utils/type-checker.js
+++ b/src/utils/type-checker.js
@@ -10,5 +10,8 @@ export default {
   },
   isString(node) {
     return this.isLiteral(node) && typeof node.value === 'string';
-  }
+  },
+  isES6Function(node) {
+    return node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration';
+  },
 };

--- a/test/transformation/let.js
+++ b/test/transformation/let.js
@@ -51,4 +51,28 @@ describe('Variable declaration var to let/const', function () {
     var script = 'var a = 0; b.a++;';
     expect(test(script)).to.equal('const a = 0; b.a++;');
   });
+
+  // Issue 75
+  it('should consider variables function-scoped', function () {
+    expect(test(
+      'var a = 0;\n' +
+      'function foo() { var a = 1; }\n' +
+      'a = 2;'
+    )).to.equal(
+      'let a = 0;\n' +
+      'function foo() { const a = 1; }\n' +
+      'a = 2;'
+    );
+  });
+
+  it('should find variables from outer scope', function () {
+    expect(test(
+      'var a = 0;\n' +
+      'function foo() { a = 1; }'
+    )).to.equal(
+      'let a = 0;\n' +
+      'function foo() { a = 1; }'
+    );
+  });
+
 });


### PR DESCRIPTION
Complete rewrite of let transform:

- Broke it all up to several smaller functions.

- Instead of single variables lookup table
  using an array (functionScopeStack) of lookup tables
  which are added/removed on entering/leaving a function.

- Used const for all variables instead of let.

- Added isES6Function() type-checker helper.

Fixes #75 

Note: This doesn't really solve all the problems with let transform. A major change is needed to properly account for variable hoisting and block scoping. But hopefully at least a change in the right direction.