### PR TITLE
Proper function- and block-scoping support for let-transform

### DIFF
--- a/src/scope/block-scope.js
+++ b/src/scope/block-scope.js
@@ -1,0 +1,48 @@
+import Scope from './scope.js';
+
+/**
+ * Container for block-scoped variables.
+ */
+export default
+class BlockScope extends Scope {
+  /**
+   * Registers variable in block scope.
+   *
+   * (All variables are first registered in function scope.)
+   *
+   * @param  {String} name Variable name
+   * @param  {Variable} variable Variable object
+   */
+  register(name, variable) {
+    this.vars[name] = variable;
+  }
+
+  /**
+   * Looks up variable from function scope.
+   *
+   * Traveling up the scope chain until reaching a function scope.
+   *
+   * @param  {String} name Variable name
+   * @return {Variable} The found variable or false
+   */
+  findFunctionScoped(name) {
+    return this.parent.findFunctionScoped(name);
+  }
+
+  /**
+   * Looks up variable from block scope.
+   *
+   * Either from the current block, or any parent block.
+   * When variable found from function scope instead,
+   * returns false to signify it's not properly block-scoped.
+   *
+   * @param  {String} name Variable name
+   * @return {Variable} The found variable or false
+   */
+  findBlockScoped(name) {
+    if (this.vars[name]) {
+      return this.vars[name];
+    }
+    return this.parent.findBlockScoped(name);
+  }
+}

--- a/src/scope/function-hoister.js
+++ b/src/scope/function-hoister.js
@@ -1,0 +1,77 @@
+import estraverse from 'estraverse';
+import * as functionType from '../utils/function-type.js';
+import Variable from '../scope/variable.js';
+import VariableGroup from '../scope/variable-group.js';
+
+/**
+ * Registers all variables defined inside a function.
+ * Emulating ECMAScript variable hoisting.
+ */
+export default
+class FunctionHoister {
+  /**
+   * Instantiates hoister with a function scope where to
+   * register the variables that are found.
+   * @param  {FunctionScope} functionScope
+   */
+  constructor(functionScope) {
+    this.functionScope = functionScope;
+  }
+
+  /**
+   * Performs the hoisting of a function name, params and variables.
+   *
+   * @param {Object} cfg
+   *   @param {Identifier} cfg.id Optional function name
+   *   @param {Identifier[]} cfg.params Optional function parameters
+   *   @param {Object} cfg.body Function body node or Program node to search variables from.
+   */
+  hoist({id, params, body}) {
+    if (id) {
+      this.hoistFunctionId(id);
+    }
+    if (params) {
+      this.hoistFunctionParams(params);
+    }
+    this.hoistVariables(body);
+  }
+
+  hoistFunctionId(id) {
+    this.functionScope.register(id.name, new Variable(id));
+  }
+
+  hoistFunctionParams(params) {
+    params.forEach(p => {
+      this.functionScope.register(p.name, new Variable(p));
+    });
+  }
+
+  hoistVariables(ast) {
+    estraverse.traverse(ast, {
+      // Use arrow-function here, so we can access outer `this`.
+      enter: (node, parent) => {
+        if (node.type === 'VariableDeclaration') {
+          this.hoistVariableDeclaration(node, parent);
+        }
+        else if (functionType.isFunctionDeclaration(node)) {
+          this.functionScope.register(node.id.name, new Variable(node));
+          // Skip anything inside the nested function
+          return estraverse.VisitorOption.Skip;
+        }
+        else if (functionType.isFunctionExpression(node)) {
+          // Skip anything inside the nested function
+          return estraverse.VisitorOption.Skip;
+        }
+      }
+    });
+  }
+
+  hoistVariableDeclaration(node, parent) {
+    const group = new VariableGroup(node, parent);
+    node.declarations.forEach(declaratorNode => {
+      const variable = new Variable(declaratorNode, group);
+      group.add(variable);
+      this.functionScope.register(declaratorNode.id.name, variable);
+    });
+  }
+}

--- a/src/scope/function-scope.js
+++ b/src/scope/function-scope.js
@@ -1,0 +1,62 @@
+import Scope from './scope.js';
+
+/**
+ * Container for function-scoped variables.
+ */
+export default
+class FunctionScope extends Scope {
+  /**
+   * Registers a variable in function scope.
+   *
+   * All variables (including function name and params) are first
+   * registered as function scoped, during hoisting phase.
+   * Later thay can also be registered in block scope.
+   *
+   * Ignores attempts to register the same variable twice.
+   *
+   * @param  {String} name Variable name
+   * @param  {Variable} variable Variable object
+   */
+  register(name, variable) {
+    if (!this.vars[name]) {
+      this.vars[name] = variable;
+    }
+  }
+
+  /**
+   * Looks up variable from function scope.
+   * (Either from this function scope or from any parent function scope.)
+   *
+   * @param  {String} name Variable name
+   * @return {Variable} The found variable or false
+   */
+  findFunctionScoped(name) {
+    if (this.vars[name]) {
+      return this.vars[name];
+    }
+    if (this.parent) {
+      return this.parent.findFunctionScoped(name);
+    }
+    return false;
+  }
+
+  /**
+   * Looks up variable from block scope.
+   * (i.e. the parent block scope of the function scope.)
+   *
+   * When variable found from function scope instead,
+   * returns false to signify it's not properly block-scoped.
+   *
+   * @param  {String} name Variable name
+   * @return {Variable} The found variable or false
+   */
+  findBlockScoped(name) {
+    if (this.vars[name]) {
+      return false;
+    }
+    if (this.parent) {
+      return this.parent.findBlockScoped(name);
+    }
+    return false;
+  }
+}

--- a/src/scope/scope-manager.js
+++ b/src/scope/scope-manager.js
@@ -1,0 +1,41 @@
+import BlockScope from '../scope/block-scope.js';
+import FunctionScope from '../scope/function-scope.js';
+
+/**
+ * Keeps track of the current function/block scope.
+ */
+export default
+class ScopeManager {
+  constructor() {
+    this.scope = undefined;
+  }
+
+  /**
+   * Enters new function scope
+   */
+  enterFunction() {
+    this.scope = new FunctionScope(this.scope);
+  }
+
+  /**
+   * Enters new block scope
+   */
+  enterBlock() {
+    this.scope = new BlockScope(this.scope);
+  }
+
+  /**
+   * Leaves the current scope.
+   */
+  leaveScope() {
+    this.scope = this.scope.getParent();
+  }
+
+  /**
+   * Returns the current scope.
+   * @return {FunctionScope|BlockScope}
+   */
+  getScope() {
+    return this.scope;
+  }
+}

--- a/src/scope/scope.js
+++ b/src/scope/scope.js
@@ -1,0 +1,37 @@
+import _ from 'lodash';
+
+/**
+ * Base class for Function- and BlockScope.
+ *
+ * Subclasses implement:
+ *
+ * - register() for adding variables to scope
+ * - findFunctionScoped() for finding function-scoped vars
+ * - findBlockScoped() for finding block-scoped vars
+ */
+export default
+class Scope {
+  /**
+   * @param  {Scope} parent Parent scope (if any).
+   */
+  constructor(parent) {
+    this.parent = parent;
+    this.vars = {};
+  }
+
+  /**
+   * Returns parent scope (possibly undefined).
+   * @return {Scope}
+   */
+  getParent() {
+    return this.parent;
+  }
+
+  /**
+   * Returns all variables registered in this scope.
+   * @return {Variable[]}
+   */
+  getVariables() {
+    return _.values(this.vars);
+  }
+}

--- a/src/scope/variable-group.js
+++ b/src/scope/variable-group.js
@@ -1,0 +1,67 @@
+/**
+ * Encapsulates a VariableDeclaration node
+ * and a list of Variable objects declared by it.
+ *
+ * PS. Named VariableGroup not VariableDeclaration to avoid confusion with syntax class.
+ */
+export default
+class VariableGroup {
+  /**
+   * @param  {VariableDeclaration} node AST node
+   * @param  {Object} parentNode Parent AST node (pretty much any node)
+   */
+  constructor(node, parentNode) {
+    this.node = node;
+    this.parentNode = parentNode;
+    this.variables = [];
+  }
+
+  /**
+   * Adds a variable to this group.
+   * @param {Variable} variable
+   */
+  add(variable) {
+    this.variables.push(variable);
+  }
+
+  /**
+   * Returns all variables declared in this group.
+   * @return {Variable[]}
+   */
+  getVariables() {
+    return this.variables;
+  }
+
+  /**
+   * Returns the `kind` value of variable defined in this group.
+   *
+   * When not all variables are of the same kind, returns undefined.
+   *
+   * @return {String} Either "var", "let", "const" or undefined.
+   */
+  getCommonKind() {
+    const firstKind = this.variables[0].getKind();
+    if (this.variables.every(v => v.getKind() === firstKind)) {
+      return firstKind;
+    }
+    else {
+      return undefined;
+    }
+  }
+
+  /**
+   * Returns the AST node
+   * @return {VariableDeclaration}
+   */
+  getNode() {
+    return this.node;
+  }
+
+  /**
+   * Returns the parent AST node (which can be pretty much anything)
+   * @return {Object}
+   */
+  getParentNode() {
+    return this.parentNode;
+  }
+}

--- a/src/scope/variable-marker.js
+++ b/src/scope/variable-marker.js
@@ -1,0 +1,80 @@
+/**
+ * Labels variables in relation to their use in block scope.
+ *
+ * When variable is declared/modified/referenced not according to
+ * block scoping rules, it'll be marked hoisted.
+ */
+export default
+class VariableMarker {
+  /**
+   * @param  {ScopeManager} scopeManager
+   */
+  constructor(scopeManager) {
+    this.scopeManager = scopeManager;
+  }
+
+  /**
+   * Marks variable declared in current block scope.
+   *
+   * - Not valid block var when already declared before.
+   *
+   * @param  {String} varName
+   */
+  markDeclared(varName) {
+    const blockVar = this.getScope().findFunctionScoped(varName);
+
+    // Ignore repeated var declarations
+    if (blockVar.isDeclared()) {
+      blockVar.markHoisted();
+      return;
+    }
+
+    // Remember that it's declared and register in current block scope
+    blockVar.markDeclared();
+    this.getScope().register(varName, blockVar);
+  }
+
+  /**
+   * Marks variable modified in current block scope.
+   *
+   * - Not valid block var when not declared in current block scope.
+   *
+   * @param  {String} varName
+   */
+  markModified(varName) {
+    const blockVar = this.getScope().findBlockScoped(varName);
+    if (blockVar) {
+      blockVar.markModified();
+      return;
+    }
+
+    const funcVar = this.getScope().findFunctionScoped(varName);
+    if (funcVar) {
+      funcVar.markHoisted();
+      funcVar.markModified();
+    }
+  }
+
+  /**
+   * Marks variable referenced in current block scope.
+   *
+   * - Not valid block var when not declared in current block scope.
+   *
+   * @param  {String} varName
+   */
+  markReferenced(varName) {
+    const blockVar = this.getScope().findBlockScoped(varName);
+    if (blockVar) {
+      return;
+    }
+
+    const funcVar = this.getScope().findFunctionScoped(varName);
+    if (funcVar) {
+      funcVar.markHoisted();
+    }
+  }
+
+  getScope() {
+    return this.scopeManager.getScope();
+  }
+}

--- a/src/scope/variable.js
+++ b/src/scope/variable.js
@@ -1,0 +1,77 @@
+/**
+ * Encapsulates a single variable declaring AST node.
+ *
+ * It might be the actual VariableDeclarator node,
+ * but it might also be a function parameter or -name.
+ */
+export default
+class Variable {
+  /**
+   * @param  {Object} node AST node declaring the variable.
+   * @param  {VariableGroup} group The containing var-statement (if any).
+   */
+  constructor(node, group) {
+    this.node = node;
+    this.group = group;
+    this.declared = false;
+    this.hoisted = false;
+    this.modified = false;
+  }
+
+  markDeclared() {
+    this.declared = true;
+  }
+
+  isDeclared() {
+    return this.declared;
+  }
+
+  /**
+   * Marks that the use of the variable is not block-scoped,
+   * so it cannot be simply converted to `let` or `const`.
+   */
+  markHoisted() {
+    this.hoisted = true;
+  }
+
+  /**
+   * Marks that the variable is assigned to,
+   * so it cannot be converted to `const`.
+   */
+  markModified() {
+    this.modified = true;
+  }
+
+  /**
+   * Returns the strictest possible kind-attribute value for this variable.
+   *
+   * @return {String} Either "var", "let" or "const".
+   */
+  getKind() {
+    if (this.hoisted) {
+      return 'var';
+    }
+    else if (this.modified) {
+      return 'let';
+    }
+    else {
+      return 'const';
+    }
+  }
+
+  /**
+   * Returns the AST node that declares this variable.
+   * @return {Object}
+   */
+  getNode() {
+    return this.node;
+  }
+
+  /**
+   * Returns the containing var-statement (if any).
+   * @return {VariableGroup}
+   */
+  getGroup() {
+    return this.group;
+  }
+}

--- a/src/transformation/import-commonjs.js
+++ b/src/transformation/import-commonjs.js
@@ -1,5 +1,6 @@
 import estraverse from 'estraverse';
 import typeChecker from '../utils/type-checker.js';
+import multiReplaceStatement from '../utils/multi-replace-statement.js';
 import ImportDeclaration from '../syntax/import-declaration.js';
 import VariableDeclaration from '../syntax/variable-declaration.js';
 
@@ -20,7 +21,7 @@ function traverse(node, parent) {
       }
     });
 
-    parent.body.splice(parent.body.indexOf(node), 1, ...declarations);
+    multiReplaceStatement(parent, node, declarations);
   }
 }
 

--- a/src/transformation/let.js
+++ b/src/transformation/let.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import estraverse from 'estraverse';
 import * as functionType from '../utils/function-type.js';
 import * as variableType from '../utils/variable-type.js';
+import multiReplaceStatement from '../utils/multi-replace-statement.js';
 import ScopeManager from '../scope/scope-manager.js';
 import VariableMarker from '../scope/variable-marker.js';
 import FunctionHoister from '../scope/function-hoister.js';
@@ -129,7 +130,7 @@ function transformVarsToLetOrConst() {
         return new VariableDeclaration(v.getKind(), [v.getNode()]);
       });
 
-      replaceStatement(group.getParentNode(), group.getNode(), varNodes);
+      multiReplaceStatement(group.getParentNode(), group.getNode(), varNodes);
     }
   });
 }
@@ -143,10 +144,6 @@ function getFunctionVariableGroups() {
     .uniq()
     .compact()
     .value();
-}
-
-function replaceStatement(parentNode, node, replacementNodes) {
-  parentNode.body.splice(parentNode.body.indexOf(node), 1, ...replacementNodes);
 }
 
 function getScope() {

--- a/src/utils/function-type.js
+++ b/src/utils/function-type.js
@@ -1,0 +1,20 @@
+/**
+ * True when node is any kind of function.
+ */
+export function isFunction(node) {
+  return isFunctionDeclaration(node) || isFunctionExpression(node);
+}
+
+/**
+ * True when node is (arrow) function expression.
+ */
+export function isFunctionExpression(node) {
+  return node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression';
+}
+
+/**
+ * True when node is function declaration.
+ */
+export function isFunctionDeclaration(node) {
+  return node.type === 'FunctionDeclaration';
+}

--- a/src/utils/multi-replace-statement.js
+++ b/src/utils/multi-replace-statement.js
@@ -1,0 +1,16 @@
+/**
+ * Replaces `node` inside `parentNode` with any number of `replacementNodes`.
+ *
+ * ESTraverse only allows replacing one node with a single other node.
+ * This function overcomes this limitation, allowing to replace it with multiple nodes.
+ *
+ * NOTE: Only works for Statement nodes.
+ *
+ * @param  {Object} parentNode
+ * @param  {Object} node
+ * @param  {Object[]} replacementNodes
+ */
+export default
+function multiReplaceStatement(parentNode, node, replacementNodes) {
+  parentNode.body.splice(parentNode.body.indexOf(node), 1, ...replacementNodes);
+}

--- a/src/utils/type-checker.js
+++ b/src/utils/type-checker.js
@@ -11,7 +11,4 @@ export default {
   isString(node) {
     return this.isLiteral(node) && typeof node.value === 'string';
   },
-  isES6Function(node) {
-    return node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration';
-  },
 };

--- a/src/utils/variable-type.js
+++ b/src/utils/variable-type.js
@@ -1,0 +1,65 @@
+import {isFunction} from './function-type.js';
+
+/**
+ * True when node is variable assignment expression (like x += 1).
+ *
+ * @param {Object} node
+ * @return {Boolean}
+ */
+export function isAssignment(node) {
+  return node.type === 'AssignmentExpression' && node.left.type === 'Identifier';
+}
+
+/**
+ * True when node is variable update expression (like x++).
+ *
+ * @param {Object} node
+ * @return {Boolean}
+ */
+export function isUpdate(node) {
+  return node.type === 'UpdateExpression' && node.argument.type === 'Identifier';
+}
+
+/**
+ * True when node is reference to a variable.
+ *
+ * That is it's an identifier, that's not used:
+ *
+ * - as function name in function declaration/expression,
+ * - as parameter name in function declaration/expression,
+ * - as declared variable name in variable declaration,
+ * - as object property name in member expression.
+ * - as object property name in object literal.
+ *
+ * @param {Object} node
+ * @param {Object} parent Immediate parent node (to determine context)
+ * @return {Boolean}
+ */
+export function isReference(node, parent) {
+  return node.type === 'Identifier' &&
+    !isFunctionName(node, parent) &&
+    !isFunctionParameter(node, parent) &&
+    !isDeclaredVariable(node, parent) &&
+    !isPropertyInMemberExpression(node, parent) &&
+    !isPropertyInObjectLiteral(node, parent);
+}
+
+function isFunctionName(node, parent) {
+  return isFunction(parent) && parent.id === node;
+}
+
+function isFunctionParameter(node, parent) {
+  return isFunction(parent) && parent.params.some(p => p === node);
+}
+
+function isDeclaredVariable(node, parent) {
+  return parent.type === 'VariableDeclarator' && parent.id === node;
+}
+
+function isPropertyInMemberExpression(node, parent) {
+  return parent.type === 'MemberExpression' && parent.property === node;
+}
+
+function isPropertyInObjectLiteral(node, parent) {
+  return parent.type === 'Property' && parent.key === node;
+}

--- a/test/transformation/let.js
+++ b/test/transformation/let.js
@@ -10,69 +10,519 @@ function test(script) {
   return transformer.out();
 }
 
-describe('Variable declaration var to let/const', function () {
+function expectNoChange(script) {
+  expect(test(script)).to.equal(script);
+}
 
-  it('should use const for consistent variables', function () {
-    var script = 'var test = 2;';
+describe('Let/const transformation', function () {
 
-    expect(test(script)).to.equal('const test = 2;');
+  describe('with uninitialized variable', function () {
+    it('should use let when never used afterwards', function () {
+      expect(test(
+        'var x;'
+      )).to.equal(
+        'let x;'
+      );
+    });
+
+    it('should use let when assigned aftwerwards', function () {
+      expect(test(
+        'var x;\n' +
+        'x = 6;'
+      )).to.equal(
+        'let x;\n' +
+        'x = 6;'
+      );
+    });
   });
 
-  it('should use let for re-assigned variables', function () {
-    var script = 'var test = 5; test = 6;';
+  describe('with initialized variable', function () {
+    it('should use const when never used afterwards', function () {
+      expect(test(
+        'var x = 2;'
+      )).to.equal(
+        'const x = 2;'
+      );
+    });
 
-    expect(test(script)).to.equal('let test = 5; test = 6;');
+    it('should use const when only referenced afterwards', function () {
+      expect(test(
+        'var x = 2;\n' +
+        'foo(x);'
+      )).to.equal(
+        'const x = 2;\n' +
+        'foo(x);'
+      );
+    });
+
+    it('should use let when re-assigned afterwards', function () {
+      expect(test(
+        'var x = 5;\n' +
+        'x = 6;'
+      )).to.equal(
+        'let x = 5;\n' +
+        'x = 6;'
+      );
+    });
+
+    it('should use let when updated aftwerwards', function () {
+      expect(test(
+        'var x = 5;\n' +
+        'x++;'
+      )).to.equal(
+        'let x = 5;\n' +
+        'x++;'
+      );
+    });
   });
 
-  it('should work for multiple declarations', function() {
-    var script = 'var x = 2, y = 3; x = 5;';
+  describe('with multi-variable declaration', function () {
+    it('should use const when not referenced afterwards', function () {
+      expect(test(
+        'var x = 1, y = 2;'
+      )).to.equal(
+        'const x = 1, y = 2;'
+      );
+    });
 
-    expect(test(script)).to.equal('let x = 2, y = 3; x = 5;');
+    it('should use let when assigned to afterwards', function () {
+      expect(test(
+        'var x = 1, y = 2;\n' +
+        'x = 3;\n' +
+        'y = 4;'
+      )).to.equal(
+        'let x = 1, y = 2;\n' +
+        'x = 3;\n' +
+        'y = 4;'
+      );
+    });
+
+    it('should use let when initially unassigned but assigned afterwards', function () {
+      expect(test(
+        'var x, y;\n' +
+        'x = 3;\n' +
+        'y = 4;'
+      )).to.equal(
+        'let x, y;\n' +
+        'x = 3;\n' +
+        'y = 4;'
+      );
+    });
+
+    it('should split to let & const when only some vars assigned to afterwards', function () {
+      expect(test(
+        'var x = 1, y = 2;\n' +
+        'y = 4;'
+      )).to.equal(
+        'const x = 1;\n' +
+        'let y = 2;\n' +
+        'y = 4;'
+      );
+    });
+
+    it('should split to let & var when only some vars are block-scoped', function () {
+      expect(test(
+        'if (true) {\n' +
+        '  var x = 1, y = 2;\n' +
+        '  x = 10;\n' +
+        '}\n' +
+        'y = 20;'
+      )).to.equal(
+        'if (true) {\n' +
+        '  let x = 1;\n' +
+        '  var y = 2;\n' +
+        '  x = 10;\n' +
+        '}\n' +
+        'y = 20;'
+      );
+    });
   });
 
-  // Issue 31
-  it('should not throw error for variables without var keyword', function () {
-    var script = 'x = 2; this.y = 5;';
-    expect(test(script)).to.equal('x = 2; this.y = 5;');
+  describe('with nested function', function () {
+    it('should use let when variable re-declared inside it', function () {
+      expect(test(
+        'var a = 0;\n' +
+        'function foo() { var a = 1; }\n' +
+        'a = 2;'
+      )).to.equal(
+        'let a = 0;\n' +
+        'function foo() { const a = 1; }\n' +
+        'a = 2;'
+      );
+    });
+
+    it('should use let when variable assigned inside it', function () {
+      expect(test(
+        'var a = 0;\n' +
+        'function foo() { a = 1; }'
+      )).to.equal(
+        'let a = 0;\n' +
+        'function foo() { a = 1; }'
+      );
+    });
+
+    it('should use const when variable referenced inside it', function () {
+      expect(test(
+        'var a = 0;\n' +
+        'function foo() { bar(a); }'
+      )).to.equal(
+        'const a = 0;\n' +
+        'function foo() { bar(a); }'
+      );
+    });
+
+    it('should use const when variable redeclared as parameter', function () {
+      expect(test(
+        'var a = 0;\n' +
+        'function foo(a) { a = 1; }'
+      )).to.equal(
+        'const a = 0;\n' +
+        'function foo(a) { a = 1; }'
+      );
+    });
   });
 
-  it('should use let for updated variables', function () {
-    var script = 'var i = 0; i++;';
-    expect(test(script)).to.equal('let i = 0; i++;');
+  describe('with nested arrow-function', function () {
+    it('should use let when variable re-declared inside it', function () {
+      expect(test(
+        'var a = 0;\n' +
+        '() => { var a = 1; };\n' +
+        'a = 2;'
+      )).to.equal(
+        'let a = 0;\n' +
+        '() => { const a = 1; };\n' +
+        'a = 2;'
+      );
+    });
+
+    it('should use let when variable assigned inside it', function () {
+      expect(test(
+        'var a = 0;\n' +
+        '() => { a = 1; };'
+      )).to.equal(
+        'let a = 0;\n' +
+        '() => { a = 1; };'
+      );
+    });
+
+    it('should use const when variable referenced inside it', function () {
+      expect(test(
+        'var a = 0;\n' +
+        '() => { bar(a); };'
+      )).to.equal(
+        'const a = 0;\n' +
+        '() => { bar(a); };'
+      );
+    });
+
+    it('should use const when variable redeclared as parameter', function () {
+      expect(test(
+        'var a = 0;\n' +
+        '(a) => a = 1;'
+      )).to.equal(
+        'const a = 0;\n' +
+        '(a) => a = 1;'
+      );
+    });
   });
 
-  // Issue 53
-  it('should use const when similarly-named property is assigned to', function () {
-    var script = 'var a = 0; b.a += 1;';
-    expect(test(script)).to.equal('const a = 0; b.a += 1;');
+  describe('with nested block', function () {
+    it('should use let when variable assigned in it', function () {
+      expect(test(
+        'var a = 0;\n' +
+        'if (true) { a = 1; }'
+      )).to.equal(
+        'let a = 0;\n' +
+        'if (true) { a = 1; }'
+      );
+    });
+
+    it('should use const when variable referenced in it', function () {
+      expect(test(
+        'var a = 0;\n' +
+        'if (true) { foo(a); }'
+      )).to.equal(
+        'const a = 0;\n' +
+        'if (true) { foo(a); }'
+      );
+    });
+
+    it('should use let when variable only assigned inside a single block', function () {
+      expect(test(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '  a = 2;\n' +
+        '}'
+      )).to.equal(
+        'if (true) {\n' +
+        '  let a = 1;\n' +
+        '  a = 2;\n' +
+        '}'
+      );
+    });
+
+    it('should use const when variable only referenced inside a single block', function () {
+      expect(test(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '  foo(a);\n' +
+        '}'
+      )).to.equal(
+        'if (true) {\n' +
+        '  const a = 1;\n' +
+        '  foo(a);\n' +
+        '}'
+      );
+    });
+
+    it('should use let when variable assigned inside further nested block', function () {
+      expect(test(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '  if (false) { a = 2; }\n' +
+        '}'
+      )).to.equal(
+        'if (true) {\n' +
+        '  let a = 1;\n' +
+        '  if (false) { a = 2; }\n' +
+        '}'
+      );
+    });
+
+    it('should use const when variable referenced inside further nested block', function () {
+      expect(test(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '  if (false) { foo(a); }\n' +
+        '}'
+      )).to.equal(
+        'if (true) {\n' +
+        '  const a = 1;\n' +
+        '  if (false) { foo(a); }\n' +
+        '}'
+      );
+    });
+
+    it('should ignore variable declared inside a block but assigned outside', function () {
+      expectNoChange(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '}\n' +
+        'a += 1;'
+      );
+    });
+
+    it('should ignore variable declared inside a block but referenced outside', function () {
+      expectNoChange(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '}\n' +
+        'foo(a);'
+      );
+    });
+
+    it('should use const when variable name used in object property outside the block', function () {
+      expect(test(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '}\n' +
+        'obj.a = 2;\n' +
+        'x = {a: 2};'
+      )).to.equal(
+        'if (true) {\n' +
+        '  const a = 1;\n' +
+        '}\n' +
+        'obj.a = 2;\n' +
+        'x = {a: 2};'
+      );
+    });
+
+    it('should use const when variable name used as function expression name outside the block', function () {
+      expect(test(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '}\n' +
+        'fn = function a() {}'
+      )).to.equal(
+        'if (true) {\n' +
+        '  const a = 1;\n' +
+        '}\n' +
+        'fn = function a() {}'
+      );
+    });
+
+    it('should use const when variable name used as function parameter name outside the block', function () {
+      expect(test(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '}\n' +
+        'function fn(a) {}'
+      )).to.equal(
+        'if (true) {\n' +
+        '  const a = 1;\n' +
+        '}\n' +
+        'function fn(a) {}'
+      );
+    });
+
+    it('should use const when variable name used as arrow-function parameter name outside the block', function () {
+      expect(test(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '}\n' +
+        'fn = (a) => {};'
+      )).to.equal(
+        'if (true) {\n' +
+        '  const a = 1;\n' +
+        '}\n' +
+        'fn = (a) => {};'
+      );
+    });
+
+    it('should ignore variable referenced in function body outside the block', function () {
+      expectNoChange(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '}\n' +
+        'fn = function() { return a; }'
+      );
+    });
+
+    it('should ignore variable referenced in shorthand arrow-function body outside the block', function () {
+      expectNoChange(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '}\n' +
+        'fn = () => a;'
+      );
+    });
+
+    it('should ignore variable referenced in variable declaration outside the block', function () {
+      expectNoChange(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '}\n' +
+        'const foo = a;'
+      );
+    });
   });
 
-  it('should use const when similarly-named property is updated', function () {
-    var script = 'var a = 0; b.a++;';
-    expect(test(script)).to.equal('const a = 0; b.a++;');
+  // Variable hoisting
+  describe('with variable assigned before declared', function () {
+    it('should ignore', function () {
+      expectNoChange(
+        'a = 1;\n' +
+        'var a = 2;'
+      );
+    });
+
+    it('should ignore when similar variable in outer scope', function () {
+      expect(test(
+        'var a = 0;\n' +
+        'function foo() {\n' +
+        '  a = 1;\n' +
+        '  var a = 2;\n' +
+        '}'
+      )).to.equal(
+        'const a = 0;\n' +
+        'function foo() {\n' +
+        '  a = 1;\n' +
+        '  var a = 2;\n' +
+        '}'
+      );
+    });
   });
 
-  // Issue 75
-  it('should consider variables function-scoped', function () {
-    expect(test(
-      'var a = 0;\n' +
-      'function foo() { var a = 1; }\n' +
-      'a = 2;'
-    )).to.equal(
-      'let a = 0;\n' +
-      'function foo() { const a = 1; }\n' +
-      'a = 2;'
-    );
+  describe('with variable referenced before declared', function () {
+    it('should ignore', function () {
+      expectNoChange(
+        'foo(a);\n' +
+        'var a = 2;'
+      );
+    });
   });
 
-  it('should find variables from outer scope', function () {
-    expect(test(
-      'var a = 0;\n' +
-      'function foo() { a = 1; }'
-    )).to.equal(
-      'let a = 0;\n' +
-      'function foo() { a = 1; }'
-    );
+  describe('with repeated variable declarations', function() {
+    it('should ignore', function () {
+      expectNoChange(
+        'var a = 1;\n' +
+        'var a = 2;'
+      );
+    });
+
+    it('should ignore when declarations in different blocks', function () {
+      expectNoChange(
+        'if (true) {\n' +
+        '  var a = 1;\n' +
+        '}\n' +
+        'if (true) {\n' +
+        '  var a;\n' +
+        '  foo(a);\n' +
+        '}'
+      );
+    });
+
+    it('should ignore when re-declaring of function parameter', function () {
+      expectNoChange(
+        'function foo(a) {\n' +
+        '  var a = 1;\n' +
+        '}'
+      );
+    });
+
+    it('should ignore when re-declaring of function expression name', function () {
+      expectNoChange(
+        '(function foo(a) {\n' +
+        '  var foo;\n' +
+        '  return foo;\n' +
+        '})();'
+      );
+    });
+
+    it('should allow re-declaring of function declaration name', function () {
+      expect(test(
+        'function foo(a) {\n' +
+        '  var foo;\n' +
+        '  return foo;\n' +
+        '}'
+      )).to.equal(
+        'function foo(a) {\n' +
+        '  let foo;\n' +
+        '  return foo;\n' +
+        '}'
+      );
+    });
+  });
+
+  // Possible errors (Issues #31 and #53)
+  describe('regression tests', function() {
+    it('should not throw error for assignment to undeclared variable', function () {
+      expectNoChange('x = 2;');
+    });
+
+    it('should not throw error for assignment to object property', function () {
+      expectNoChange('this.y = 5;');
+    });
+
+    it('should use const when similarly-named property is assigned to', function () {
+      expect(test(
+        'var x = 2;\n' +
+        'b.x += 1;'
+      )).to.equal(
+        'const x = 2;\n' +
+        'b.x += 1;'
+      );
+    });
+
+    it('should use const when similarly-named property is updated', function () {
+      expect(test(
+        'var x = 2;\n' +
+        'b.x++;'
+      )).to.equal(
+        'const x = 2;\n' +
+        'b.x++;'
+      );
+    });
   });
 
 });


### PR DESCRIPTION
Took a while, but here it finally is.

Rewrote the whole let-transform to correctly handle JavaScript variable scoping.

- No more transforms `var` declarations that aren't properly block-scoped. Fixes #76 
- Splits multi-variable declarations up to multiple declarations when some can be converted to `const` and some to `let`.
- Considers function names and parameters also as variables, ignoring `var` declarations that re-declare them.
- Handles arrow-functions.

The resulting code is way larger than the old version, split over several files. Most of the new stuff is in new `scope/` dir. There are also some new utilities in `utils/` dir. The diff of `let-transform.js` is not really worth reading - it's a complete rewrite, so the similarities are more of an accidental kind.

Also added loads of new tests and restructured the existing ones. Ran it also over 15K lines of JavaScript in my work project and now it finally worked.

Tried to make the code as readable as possible, but the whole scoping thing is inherently kinda complex, so feel free to ask any questions about the code.

**Further work & ideas**

- Support ES6 variable destructuring.
- Recognize existing `let` & `const` declarations.
- Output a warning when failing to convert `var` to `let`/`const`. (That's actually really easy to add, and would be really useful information.)
- Make `const` conversion optional. (Some people might only care about converting `var` to `let`.)