### PR TITLE
Simpler Transformer class

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -14,6 +14,4 @@ catch (error) {
 }
 
 var transformer = new Transformer(options.transformers);
-transformer.read(io.read(options.inFile));
-transformer.applyTransformations();
-io.write(options.outFile, transformer.out());
+io.write(options.outFile, transformer.run(io.read(options.inFile)));

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,7 +13,7 @@ catch (error) {
   process.exit(2);
 }
 
-var transformer = new Transformer({transformers: options.transformers});
+var transformer = new Transformer(options.transformers);
 transformer.read(io.read(options.inFile));
 transformer.applyTransformations();
 io.write(options.outFile, transformer.out());

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -26,54 +26,34 @@ const tranformersMap = {
   exportCommonjs: exportCommonjsTransformation,
 };
 
+/**
+ * Runs transformers on code.
+ */
 export default
 class Transformer {
   /**
    * @param {Object} transformers List of transformers to enable
    */
   constructor(transformers={}) {
-    this.ast = {};
-
-    this.transformations = _(transformers)
+    this.transformers = _(transformers)
       .pick(enabled => enabled)
       .map((enabled, key) => tranformersMap[key])
       .value();
   }
 
   /**
-   * Prepare an abstract syntax tree for given code in string
+   * Tranforms code using all configured transformers.
    *
-   * @param string
+   * @param {String} code Input ES5 code
+   * @return {String} Output ES6 code
    */
-  read(string) {
-    this.ast = recast.parse(string).program;
-  }
+  run(code) {
+    const ast = recast.parse(code).program;
 
-  /**
-   * Apply a transformation on the AST
-   *
-   * @param transformation
-   */
-  applyTransformation(transformation) {
-    transformation(this.ast);
-  }
+    this.transformers.forEach(transformer => {
+      transformer(ast);
+    });
 
-  /**
-   * Apply All transformations
-   */
-  applyTransformations() {
-    for (let i = 0; i < this.transformations.length; i++) {
-      let transformation = this.transformations[i];
-      this.applyTransformation(transformation);
-    }
-  }
-
-  /**
-   * Returns the code string
-   *
-   * @returns {Object}
-   */
-  out() {
-    return recast.print(this.ast).code;
+    return recast.print(ast).code;
   }
 }

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -28,12 +28,10 @@ const tranformersMap = {
 
 export default
 class Transformer {
-
   /**
    * @constructor
    */
   constructor(options = {}) {
-
     this.ast = {};
     this.options = options;
 
@@ -41,7 +39,6 @@ class Transformer {
       .pick(enabled => enabled)
       .map((enabled, key) => tranformersMap[key])
       .value();
-
   }
 
   /**
@@ -50,9 +47,7 @@ class Transformer {
    * @param string
    */
   read(string) {
-
     this.ast = recast.parse(string).program;
-
   }
 
   /**
@@ -61,22 +56,17 @@ class Transformer {
    * @param transformation
    */
   applyTransformation(transformation) {
-
     transformation(this.ast);
-
   }
 
   /**
    * Apply All transformations
    */
   applyTransformations() {
-
     for (let i = 0; i < this.transformations.length; i++) {
       let transformation = this.transformations[i];
       this.applyTransformation(transformation);
-
     }
-
   }
 
   /**
@@ -85,9 +75,6 @@ class Transformer {
    * @returns {Object}
    */
   out() {
-
     return recast.print(this.ast).code;
-
   }
-
 }

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -29,13 +29,12 @@ const tranformersMap = {
 export default
 class Transformer {
   /**
-   * @constructor
+   * @param {Object} transformers List of transformers to enable
    */
-  constructor(options = {}) {
+  constructor(transformers={}) {
     this.ast = {};
-    this.options = options;
 
-    this.transformations = _(options.transformers)
+    this.transformations = _(transformers)
       .pick(enabled => enabled)
       .map((enabled, key) => tranformersMap[key])
       .value();

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -1,12 +1,11 @@
 var expect = require('chai').expect;
 var
   Transformer = require('./../../lib/transformer'),
-  arrowTransformation = require('./../../lib/transformation/arrow-functions'),
-  transformer = new Transformer();
+  transformer = new Transformer({arrowFunctions: true});
 
 function test(script) {
   transformer.read(script);
-  transformer.applyTransformation(arrowTransformation);
+  transformer.applyTransformations();
   return transformer.out();
 }
 

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -4,9 +4,7 @@ var
   transformer = new Transformer({arrowFunctions: true});
 
 function test(script) {
-  transformer.read(script);
-  transformer.applyTransformations();
-  return transformer.out();
+  return transformer.run(script);
 }
 
 function expectNoChange(script) {

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
-var
-  Transformer = require('./../../lib/transformer'),
-  transformer = new Transformer({arrowFunctions: true});
+var Transformer = require('./../../lib/transformer');
+var transformer = new Transformer({arrowFunctions: true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/classes.js
+++ b/test/transformation/classes.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
-var
-  Transformer = require('./../../lib/transformer'),
-  transformer = new Transformer({classes: true});
+var Transformer = require('./../../lib/transformer');
+var transformer = new Transformer({classes: true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/classes.js
+++ b/test/transformation/classes.js
@@ -1,12 +1,11 @@
 var expect = require('chai').expect;
 var
   Transformer = require('./../../lib/transformer'),
-  classTransformation = require('./../../lib/transformation/classes'),
-  transformer = new Transformer();
+  transformer = new Transformer({classes: true});
 
 function test(script) {
   transformer.read(script);
-  transformer.applyTransformation(classTransformation);
+  transformer.applyTransformations();
   return transformer.out();
 }
 

--- a/test/transformation/classes.js
+++ b/test/transformation/classes.js
@@ -4,9 +4,7 @@ var
   transformer = new Transformer({classes: true});
 
 function test(script) {
-  transformer.read(script);
-  transformer.applyTransformations();
-  return transformer.out();
+  return transformer.run(script);
 }
 
 describe('Class transformation', function () {

--- a/test/transformation/comments.js
+++ b/test/transformation/comments.js
@@ -1,7 +1,18 @@
 var expect = require('chai').expect;
 var
   Transformer = require('./../../lib/transformer'),
-  transformer = new Transformer({transformers: {let: true}});
+  transformer = new Transformer({
+    classes: true,
+    stringTemplates: true,
+    arrowFunctions: true,
+    let: true,
+    defaultArguments: true,
+    objectMethods: true,
+    objectShorthands: true,
+    noStrict: true,
+    importCommonjs: true,
+    exportCommonjs: true,
+  });
 
 function test(script) {
   transformer.read(script);

--- a/test/transformation/comments.js
+++ b/test/transformation/comments.js
@@ -15,9 +15,7 @@ var
   });
 
 function test(script) {
-  transformer.read(script);
-  transformer.applyTransformations();
-  return transformer.out();
+  return transformer.run(script);
 }
 
 describe('Comments', function () {

--- a/test/transformation/comments.js
+++ b/test/transformation/comments.js
@@ -1,18 +1,17 @@
 var expect = require('chai').expect;
-var
-  Transformer = require('./../../lib/transformer'),
-  transformer = new Transformer({
-    classes: true,
-    stringTemplates: true,
-    arrowFunctions: true,
-    let: true,
-    defaultArguments: true,
-    objectMethods: true,
-    objectShorthands: true,
-    noStrict: true,
-    importCommonjs: true,
-    exportCommonjs: true,
-  });
+var Transformer = require('./../../lib/transformer');
+var transformer = new Transformer({
+  classes: true,
+  stringTemplates: true,
+  arrowFunctions: true,
+  let: true,
+  defaultArguments: true,
+  objectMethods: true,
+  objectShorthands: true,
+  noStrict: true,
+  importCommonjs: true,
+  exportCommonjs: true,
+});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/default-arguments.js
+++ b/test/transformation/default-arguments.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
-var
-  Transformer = require('./../../lib/transformer'),
-  transformer = new Transformer({defaultArguments: true});
+var Transformer = require('./../../lib/transformer');
+var transformer = new Transformer({defaultArguments: true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/default-arguments.js
+++ b/test/transformation/default-arguments.js
@@ -1,12 +1,11 @@
 var expect = require('chai').expect;
 var
   Transformer = require('./../../lib/transformer'),
-  defaultArgsTransformation = require('./../../lib/transformation/default-arguments'),
-  transformer = new Transformer();
+  transformer = new Transformer({defaultArguments: true});
 
 function test(script) {
   transformer.read(script);
-  transformer.applyTransformation(defaultArgsTransformation);
+  transformer.applyTransformations();
   return transformer.out();
 }
 

--- a/test/transformation/default-arguments.js
+++ b/test/transformation/default-arguments.js
@@ -4,9 +4,7 @@ var
   transformer = new Transformer({defaultArguments: true});
 
 function test(script) {
-  transformer.read(script);
-  transformer.applyTransformations();
-  return transformer.out();
+  return transformer.run(script);
 }
 
 describe('Default Arguments', function () {

--- a/test/transformation/export-commonjs.js
+++ b/test/transformation/export-commonjs.js
@@ -1,12 +1,11 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var exportCommonJsTransformation = require('./../../lib/transformation/export-commonjs');
 
-var transformer = new Transformer({});
+var transformer = new Transformer({exportCommonjs: true});
 
 function test(script) {
   transformer.read(script);
-  transformer.applyTransformation(exportCommonJsTransformation);
+  transformer.applyTransformations();
   return transformer.out();
 }
 

--- a/test/transformation/export-commonjs.js
+++ b/test/transformation/export-commonjs.js
@@ -1,6 +1,5 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-
 var transformer = new Transformer({exportCommonjs: true});
 
 function test(script) {

--- a/test/transformation/export-commonjs.js
+++ b/test/transformation/export-commonjs.js
@@ -4,9 +4,7 @@ var Transformer = require('./../../lib/transformer');
 var transformer = new Transformer({exportCommonjs: true});
 
 function test(script) {
-  transformer.read(script);
-  transformer.applyTransformations();
-  return transformer.out();
+  return transformer.run(script);
 }
 
 function expectNoChange(script) {

--- a/test/transformation/import-commonjs.js
+++ b/test/transformation/import-commonjs.js
@@ -1,12 +1,11 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var importCommonJsTransformation = require('./../../lib/transformation/import-commonjs');
 
-var transformer = new Transformer({});
+var transformer = new Transformer({importCommonjs: true});
 
 function test(script) {
   transformer.read(script);
-  transformer.applyTransformation(importCommonJsTransformation);
+  transformer.applyTransformations();
   return transformer.out();
 }
 

--- a/test/transformation/import-commonjs.js
+++ b/test/transformation/import-commonjs.js
@@ -1,6 +1,5 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-
 var transformer = new Transformer({importCommonjs: true});
 
 function test(script) {

--- a/test/transformation/import-commonjs.js
+++ b/test/transformation/import-commonjs.js
@@ -4,9 +4,7 @@ var Transformer = require('./../../lib/transformer');
 var transformer = new Transformer({importCommonjs: true});
 
 function test(script) {
-  transformer.read(script);
-  transformer.applyTransformations();
-  return transformer.out();
+  return transformer.run(script);
 }
 
 function expectNoChange(script) {

--- a/test/transformation/let.js
+++ b/test/transformation/let.js
@@ -4,9 +4,7 @@ var
   transformer = new Transformer({let: true});
 
 function test(script) {
-  transformer.read(script);
-  transformer.applyTransformations();
-  return transformer.out();
+  return transformer.run(script);
 }
 
 function expectNoChange(script) {

--- a/test/transformation/let.js
+++ b/test/transformation/let.js
@@ -1,12 +1,11 @@
 var expect = require('chai').expect;
 var
   Transformer = require('./../../lib/transformer'),
-  letTransformation = require('./../../lib/transformation/let'),
-  transformer = new Transformer();
+  transformer = new Transformer({let: true});
 
 function test(script) {
   transformer.read(script);
-  transformer.applyTransformation(letTransformation);
+  transformer.applyTransformations();
   return transformer.out();
 }
 

--- a/test/transformation/let.js
+++ b/test/transformation/let.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
-var
-  Transformer = require('./../../lib/transformer'),
-  transformer = new Transformer({let: true});
+var Transformer = require('./../../lib/transformer');
+var transformer = new Transformer({let: true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/no-strict.js
+++ b/test/transformation/no-strict.js
@@ -1,12 +1,11 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var noStrictTransformation = require('./../../lib/transformation/no-strict');
 
-var transformer = new Transformer({});
+var transformer = new Transformer({noStrict: true});
 
 function test(script) {
   transformer.read(script);
-  transformer.applyTransformation(noStrictTransformation);
+  transformer.applyTransformations();
   return transformer.out();
 }
 

--- a/test/transformation/no-strict.js
+++ b/test/transformation/no-strict.js
@@ -4,9 +4,7 @@ var Transformer = require('./../../lib/transformer');
 var transformer = new Transformer({noStrict: true});
 
 function test(script) {
-  transformer.read(script);
-  transformer.applyTransformations();
-  return transformer.out();
+  return transformer.run(script);
 }
 
 describe('Removal of "use strict"', function () {

--- a/test/transformation/no-strict.js
+++ b/test/transformation/no-strict.js
@@ -1,6 +1,5 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-
 var transformer = new Transformer({noStrict: true});
 
 function test(script) {

--- a/test/transformation/object-methods.js
+++ b/test/transformation/object-methods.js
@@ -4,9 +4,7 @@ var
   transformer = new Transformer({objectMethods: true});
 
 function test(script) {
-  transformer.read(script);
-  transformer.applyTransformations();
-  return transformer.out();
+  return transformer.run(script);
 }
 
 describe('Object methods', function () {

--- a/test/transformation/object-methods.js
+++ b/test/transformation/object-methods.js
@@ -1,12 +1,11 @@
 var expect = require('chai').expect;
 var
   Transformer = require('./../../lib/transformer'),
-  objectMethodsTransformation = require('./../../lib/transformation/object-methods'),
-  transformer = new Transformer();
+  transformer = new Transformer({objectMethods: true});
 
 function test(script) {
   transformer.read(script);
-  transformer.applyTransformation(objectMethodsTransformation);
+  transformer.applyTransformations();
   return transformer.out();
 }
 

--- a/test/transformation/object-methods.js
+++ b/test/transformation/object-methods.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
-var
-  Transformer = require('./../../lib/transformer'),
-  transformer = new Transformer({objectMethods: true});
+var Transformer = require('./../../lib/transformer');
+var transformer = new Transformer({objectMethods: true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/object-shorthands.js
+++ b/test/transformation/object-shorthands.js
@@ -1,6 +1,5 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-
 var transformer = new Transformer({objectShorthands: true});
 
 function test(script) {

--- a/test/transformation/object-shorthands.js
+++ b/test/transformation/object-shorthands.js
@@ -4,9 +4,7 @@ var Transformer = require('./../../lib/transformer');
 var transformer = new Transformer({objectShorthands: true});
 
 function test(script) {
-  transformer.read(script);
-  transformer.applyTransformations();
-  return transformer.out();
+  return transformer.run(script);
 }
 
 describe('Object shorthands', function () {

--- a/test/transformation/object-shorthands.js
+++ b/test/transformation/object-shorthands.js
@@ -1,12 +1,11 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var objectShorthandsTransformation = require('./../../lib/transformation/object-shorthands');
 
-var transformer = new Transformer({});
+var transformer = new Transformer({objectShorthands: true});
 
 function test(script) {
   transformer.read(script);
-  transformer.applyTransformation(objectShorthandsTransformation);
+  transformer.applyTransformations();
   return transformer.out();
 }
 

--- a/test/transformation/template-string.js
+++ b/test/transformation/template-string.js
@@ -4,9 +4,7 @@ var
   transformer = new Transformer({stringTemplates: true});
 
 function test(script) {
-  transformer.read(script);
-  transformer.applyTransformations();
-  return transformer.out();
+  return transformer.run(script);
 }
 
 describe('Template string transformation', function () {

--- a/test/transformation/template-string.js
+++ b/test/transformation/template-string.js
@@ -1,12 +1,11 @@
 var expect = require('chai').expect;
 var
   Transformer = require('./../../lib/transformer'),
-  templateTransformation = require('./../../lib/transformation/template-string'),
-  transformer = new Transformer();
+  transformer = new Transformer({stringTemplates: true});
 
 function test(script) {
   transformer.read(script);
-  transformer.applyTransformation(templateTransformation);
+  transformer.applyTransformations();
   return transformer.out();
 }
 

--- a/test/transformation/template-string.js
+++ b/test/transformation/template-string.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
-var
-  Transformer = require('./../../lib/transformer'),
-  transformer = new Transformer({stringTemplates: true});
+var Transformer = require('./../../lib/transformer');
+var transformer = new Transformer({stringTemplates: true});
 
 function test(script) {
   return transformer.run(script);


### PR DESCRIPTION
A bit of cleanup to change the Transformer class that has loads of methods into much simpler version that has just a single method which just takes in ES5 code and outputs ES6 code.

As a result reducing the amount of code in all places that use the Transformer, especially in tests.