### PR TITLE
Ignore #!/usr/bin/env node comment at file start

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -48,12 +48,22 @@ class Transformer {
    * @return {String} Output ES6 code
    */
   run(code) {
-    const ast = recast.parse(code);
+    return this.ignoringHashBangComment(code, (js) => {
+      const ast = recast.parse(js);
 
-    this.transformers.forEach(transformer => {
-      transformer(ast.program);
+      this.transformers.forEach(transformer => {
+        transformer(ast.program);
+      });
+
+      return recast.print(ast).code;
     });
+  }
 
-    return recast.print(ast).code;
+  // strips hashBang comment,
+  // invokes callback with normal js,
+  // then re-adds the hashBang comment back
+  ignoringHashBangComment(code, callback) {
+    const [all, hashBang, js] = code.match(/^(\s*#!.*?\r?\n|)([\s\S]*)$/); // jshint ignore:line
+    return hashBang + callback(js);
   }
 }

--- a/test/transformation/comments.js
+++ b/test/transformation/comments.js
@@ -53,4 +53,30 @@ describe('Comments', function () {
     );
   });
 
+  it("ignores #! comment at the beginning of file", function () {
+    expect(test(
+      '#!/usr/bin/env node\n' +
+      'var x = 42;'
+    )).to.equal(
+      '#!/usr/bin/env node\n' +
+      'const x = 42;'
+    );
+  });
+
+  it("ignores #! comment almost at the beginning of file", function () {
+    expect(test(
+      '\n' +
+      '#!/usr/local/bin/node\n' +
+      'if (true) {\n' +
+      '  var foo = 42;\n' +
+      '}'
+    )).to.equal(
+      '\n' +
+      '#!/usr/local/bin/node\n' +
+      'if (true) {\n' +
+      '  const foo = 42;\n' +
+      '}'
+    );
+  });
+
 });


### PR DESCRIPTION
Strip the hash-bang comment before doing the actual parsing,
then add it back afterwards.

Added jshint ignore:line comment, as jshint otherwise reports
the `all` variable as unused.  But using the destrucor makes
reading the regex match so much simpler.

Fixes #55