### PR TITLE
Improved command line interface

### DIFF
--- a/src/parse-command-line-options.js
+++ b/src/parse-command-line-options.js
@@ -6,7 +6,7 @@ var _ = require('lodash');
 program.usage('[options] <file>');
 program.description(`${pkg.description}
 
-  Available transforms (+ enabled, - disabled):
+  Available transforms:
 
     + classes
     + stringTemplates
@@ -16,13 +16,11 @@ program.description(`${pkg.description}
     + objectMethods
     + objectShorthands
     + noStrict
-    - importCommonjs
-    - exportCommonjs`);
+    + commonjs`);
 program.version(pkg.version);
 program.option('-o, --out-file <out>', 'compile into a single file');
 program.option('--enable <a,b,c>', 'enable only specified transforms', v => v.split(','));
 program.option('--disable <a,b,c>', 'disable specified transforms', v => v.split(','));
-program.option('--module <commonjs>', 'transform CommonJS module syntax');
 
 /**
  * Parses and validates command line options from argv.
@@ -67,8 +65,7 @@ function getTransformers() {
     objectMethods: true,
     objectShorthands: true,
     noStrict: true,
-    importCommonjs: false,
-    exportCommonjs: false,
+    commonjs: true,
   };
 
   // When --enable used turn off everything besides the specified tranformers
@@ -81,15 +78,6 @@ function getTransformers() {
   // When --disable used, disable the specific transformers
   if (program.disable) {
     setTransformersEnabled(transformers, program.disable, false);
-  }
-
-  // When --module=commonjs used, enable CommonJS Transformers
-  if (program.module === 'commonjs') {
-    transformers.importCommonjs = true;
-    transformers.exportCommonjs = true;
-  }
-  else if (program.module) {
-    throw 'Unsupported module system "' + program.module + '".';
   }
 
   return transformers;

--- a/src/parse-command-line-options.js
+++ b/src/parse-command-line-options.js
@@ -4,12 +4,25 @@ var fs = require('fs');
 var _ = require('lodash');
 
 program.usage('[options] <file>');
-program.description(pkg.description);
+program.description(`${pkg.description}
+
+  Available transforms (+ enabled, - disabled):
+
+    + classes
+    + stringTemplates
+    + arrowFunctions
+    + let
+    + defaultArguments
+    + objectMethods
+    + objectShorthands
+    + noStrict
+    - importCommonjs
+    - exportCommonjs`);
 program.version(pkg.version);
-program.option('-o, --out-file <out>', 'Compile into a single file');
-program.option('--enable <a,b,c>', 'Enable only specified transforms', v => v.split(','));
-program.option('--disable <a,b,c>', 'Disable specified transforms', v => v.split(','));
-program.option('--module <commonjs>', 'Transform CommonJS module syntax');
+program.option('-o, --out-file <out>', 'compile into a single file');
+program.option('--enable <a,b,c>', 'enable only specified transforms', v => v.split(','));
+program.option('--disable <a,b,c>', 'disable specified transforms', v => v.split(','));
+program.option('--module <commonjs>', 'transform CommonJS module syntax');
 
 /**
  * Parses and validates command line options from argv.

--- a/src/parse-command-line-options.js
+++ b/src/parse-command-line-options.js
@@ -7,8 +7,8 @@ program.usage('[options] <file>');
 program.description(pkg.description);
 program.version(pkg.version);
 program.option('-o, --out-file <out>', 'Compile into a single file');
-program.option('-t, --transformers <a,b,c>', 'Perform only specified transforms', v => v.split(','));
-program.option('--disable-transformers <a,b,c>', 'Do not perform specified transforms', v => v.split(','));
+program.option('--enable <a,b,c>', 'Enable only specified transforms', v => v.split(','));
+program.option('--disable <a,b,c>', 'Disable specified transforms', v => v.split(','));
 program.option('--module <commonjs>', 'Transform CommonJS module syntax');
 
 /**
@@ -40,8 +40,8 @@ function getInputFile() {
 }
 
 function getTransformers() {
-  if (program.transformers && program.disableTransformers) {
-    throw 'Options --transformers and --disable-transformers can not be used together.';
+  if (program.enable && program.disable) {
+    throw 'Options --enable and --disable can not be used together.';
   }
 
   // All enabled by default
@@ -58,16 +58,16 @@ function getTransformers() {
     exportCommonjs: false,
   };
 
-  // When --transformers used turn off everything besides the specified tranformers
-  if (program.transformers) {
+  // When --enable used turn off everything besides the specified tranformers
+  if (program.enable) {
     transformers = _.mapValues(transformers, _.constant(false));
 
-    setTransformersEnabled(transformers, program.transformers, true);
+    setTransformersEnabled(transformers, program.enable, true);
   }
 
-  // When --disable-transformers used, disable the specific transformers
-  if (program.disableTransformers) {
-    setTransformersEnabled(transformers, program.disableTransformers, false);
+  // When --disable used, disable the specific transformers
+  if (program.disable) {
+    setTransformersEnabled(transformers, program.disable, false);
   }
 
   // When --module=commonjs used, enable CommonJS Transformers

--- a/src/parse-command-line-options.js
+++ b/src/parse-command-line-options.js
@@ -8,15 +8,15 @@ program.description(`${pkg.description}
 
   Available transforms:
 
-    + classes
-    + stringTemplates
-    + arrowFunctions
-    + let
-    + defaultArguments
-    + objectMethods
-    + objectShorthands
-    + noStrict
-    + commonjs`);
+    + class .......... prototype assignments to class declaration
+    + template ....... string concatenation to template string
+    + arrow .......... callback to arrow function
+    + let ............ var to let/const
+    + default-param .. use of || to default parameters
+    + obj-method ..... function values in objects to methods
+    + obj-shorthand .. {foo: foo} to {foo}
+    + no-strict ...... remove "use strict" directives
+    + commonjs ....... CommonJS module loading to import/export`);
 program.version(pkg.version);
 program.option('-o, --out-file <out>', 'compile into a single file');
 program.option('--enable <a,b,c>', 'enable only specified transforms', v => v.split(','));
@@ -57,15 +57,15 @@ function getTransformers() {
 
   // All enabled by default
   var transformers = {
-    classes: true,
-    stringTemplates: true,
-    arrowFunctions: true,
-    let: true,
-    defaultArguments: true,
-    objectMethods: true,
-    objectShorthands: true,
-    noStrict: true,
-    commonjs: true,
+    'class': true,
+    'template': true,
+    'arrow': true,
+    'let': true,
+    'default-param': true,
+    'obj-method': true,
+    'obj-shorthand': true,
+    'no-strict': true,
+    'commonjs': true,
   };
 
   // When --enable used turn off everything besides the specified tranformers

--- a/src/transformation/commonjs.js
+++ b/src/transformation/commonjs.js
@@ -1,0 +1,7 @@
+import importCommonjs from './import-commonjs.js';
+import exportCommonjs from './export-commonjs.js';
+
+export default function(ast) {
+  importCommonjs(ast);
+  exportCommonjs(ast);
+}

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -13,15 +13,15 @@ import noStrictTransformation from './transformation/no-strict.js';
 import commonjsTransformation from './transformation/commonjs.js';
 
 const tranformersMap = {
-  classes: classTransformation,
-  stringTemplates: templateStringTransformation,
-  arrowFunctions: arrowFunctionTransformation,
-  let: letTransformation,
-  defaultArguments: defaultArgsTransformation,
-  objectMethods: objectMethodsTransformation,
-  objectShorthands: objectShorthandsTransformation,
-  noStrict: noStrictTransformation,
-  commonjs: commonjsTransformation,
+  'class': classTransformation,
+  'template': templateStringTransformation,
+  'arrow': arrowFunctionTransformation,
+  'let': letTransformation,
+  'default-param': defaultArgsTransformation,
+  'obj-method': objectMethodsTransformation,
+  'obj-shorthand': objectShorthandsTransformation,
+  'no-strict': noStrictTransformation,
+  'commonjs': commonjsTransformation,
 };
 
 /**

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -10,8 +10,7 @@ import defaultArgsTransformation from './transformation/default-arguments.js';
 import objectMethodsTransformation from './transformation/object-methods.js';
 import objectShorthandsTransformation from './transformation/object-shorthands.js';
 import noStrictTransformation from './transformation/no-strict.js';
-import importCommonjsTransformation from './transformation/import-commonjs.js';
-import exportCommonjsTransformation from './transformation/export-commonjs.js';
+import commonjsTransformation from './transformation/commonjs.js';
 
 const tranformersMap = {
   classes: classTransformation,
@@ -22,8 +21,7 @@ const tranformersMap = {
   objectMethods: objectMethodsTransformation,
   objectShorthands: objectShorthandsTransformation,
   noStrict: noStrictTransformation,
-  importCommonjs: importCommonjsTransformation,
-  exportCommonjs: exportCommonjsTransformation,
+  commonjs: commonjsTransformation,
 };
 
 /**

--- a/test/bin.js
+++ b/test/bin.js
@@ -52,7 +52,7 @@ describe('Smoke test for the executable script', function () {
 
   describe('when invalid transform name given', function () {
     it('exits with error message', function (done) {
-      exec('node ./bin/index.js -t blah test/test-data.js', function (error, stdout, stderr) {
+      exec('node ./bin/index.js --enable blah test/test-data.js', function (error, stdout, stderr) {
         expect(error).not.to.equal(null);
         expect(stderr).to.equal('Unknown transformer "blah".\n');
         expect(stdout).to.equal('');

--- a/test/parse-command-line-options.js
+++ b/test/parse-command-line-options.js
@@ -47,7 +47,7 @@ describe('Command Line Interface', function () {
     expect(options.outFile).to.equal('some/file.js');
   });
 
-  it('by default enables all transformers except CommonJS import/export', function() {
+  it('by default enables all transforms', function() {
     var options = parse([]);
     expect(options.transformers).to.deep.equal({
       classes: true,
@@ -58,13 +58,12 @@ describe('Command Line Interface', function () {
       objectMethods: true,
       objectShorthands: true,
       noStrict: true,
-      importCommonjs: false,
-      exportCommonjs: false,
+      commonjs: true,
     });
   });
 
-  it('when --enable=let,noStrict given, enables only these transformers', function() {
-    var options = parse(['--enable', 'let,noStrict']);
+  it('when --enable=let,noStrict,commonjs given, enables only these transformers', function() {
+    var options = parse(['--enable', 'let,noStrict,commonjs']);
     expect(options.transformers).to.deep.equal({
       classes: false,
       stringTemplates: false,
@@ -74,8 +73,7 @@ describe('Command Line Interface', function () {
       objectMethods: false,
       objectShorthands: false,
       noStrict: true,
-      importCommonjs: false,
-      exportCommonjs: false,
+      commonjs: true,
     });
   });
 
@@ -85,8 +83,8 @@ describe('Command Line Interface', function () {
     }).to.throw('Unknown transformer "unknown".');
   });
 
-  it('when --disable=let,noStrict given, disables the specified transformers', function() {
-    var options = parse(['--disable', 'let,noStrict']);
+  it('when --disable=let,noStrict,commonjs given, disables the specified transformers', function() {
+    var options = parse(['--disable', 'let,noStrict,commonjs']);
     expect(options.transformers).to.deep.equal({
       classes: true,
       stringTemplates: true,
@@ -96,8 +94,7 @@ describe('Command Line Interface', function () {
       objectMethods: true,
       objectShorthands: true,
       noStrict: false,
-      importCommonjs: false,
-      exportCommonjs: false,
+      commonjs: false,
     });
   });
 
@@ -111,28 +108,6 @@ describe('Command Line Interface', function () {
     expect(function() {
       parse(['--enable', 'let', '--disable', 'let']);
     }).to.throw('Options --enable and --disable can not be used together.');
-  });
-
-  it('when --module=commonjs given, enables CommonJS import/export transformers', function() {
-    var options = parse(['--module', 'commonjs']);
-    expect(options.transformers).to.deep.equal({
-      classes: true,
-      stringTemplates: true,
-      arrowFunctions: true,
-      let: true,
-      defaultArguments: true,
-      objectMethods: true,
-      objectShorthands: true,
-      noStrict: true,
-      importCommonjs: true,
-      exportCommonjs: true,
-    });
-  });
-
-  it('when --module=unknown given, raises error', function() {
-    expect(function() {
-      parse(['--module', 'unknown']);
-    }).to.throw('Unsupported module system "unknown".');
   });
 
 });

--- a/test/parse-command-line-options.js
+++ b/test/parse-command-line-options.js
@@ -12,8 +12,8 @@ describe('Command Line Interface', function () {
   // we'll need to reset the state between tests.
   beforeEach(function() {
     commander.outFile = undefined;
-    commander.classes = true;
     commander.transformers = undefined;
+    commander.disableTransformers = undefined;
     commander.module = undefined;
   });
 
@@ -63,22 +63,6 @@ describe('Command Line Interface', function () {
     });
   });
 
-  it('when --no-classes given, enables all transformers except classes', function() {
-    var options = parse(['--no-classes']);
-    expect(options.transformers).to.deep.equal({
-      classes: false,
-      stringTemplates: true,
-      arrowFunctions: true,
-      let: true,
-      defaultArguments: true,
-      objectMethods: true,
-      objectShorthands: true,
-      noStrict: true,
-      importCommonjs: false,
-      exportCommonjs: false,
-    });
-  });
-
   it('when --transformers=let,noStrict given, enables only these transformers', function() {
     var options = parse(['--transformers', 'let,noStrict']);
     expect(options.transformers).to.deep.equal({
@@ -99,6 +83,34 @@ describe('Command Line Interface', function () {
     expect(function() {
       parse(['--transformers', 'unknown']);
     }).to.throw('Unknown transformer "unknown".');
+  });
+
+  it('when --disable-transformers=let,noStrict given, disables the specified transformers', function() {
+    var options = parse(['--disable-transformers', 'let,noStrict']);
+    expect(options.transformers).to.deep.equal({
+      classes: true,
+      stringTemplates: true,
+      arrowFunctions: true,
+      let: false,
+      defaultArguments: true,
+      objectMethods: true,
+      objectShorthands: true,
+      noStrict: false,
+      importCommonjs: false,
+      exportCommonjs: false,
+    });
+  });
+
+  it('when --disable-transformers=unknown given, raises error', function() {
+    expect(function() {
+      parse(['--disable-transformers', 'unknown']);
+    }).to.throw('Unknown transformer "unknown".');
+  });
+
+  it('when --transforms and --disable-transformers used together, raises error', function() {
+    expect(function() {
+      parse(['--transformers', 'let', '--disable-transformers', 'let']);
+    }).to.throw('Options --transformers and --disable-transformers can not be used together.');
   });
 
   it('when --module=commonjs given, enables CommonJS import/export transformers', function() {

--- a/test/parse-command-line-options.js
+++ b/test/parse-command-line-options.js
@@ -12,8 +12,8 @@ describe('Command Line Interface', function () {
   // we'll need to reset the state between tests.
   beforeEach(function() {
     commander.outFile = undefined;
-    commander.transformers = undefined;
-    commander.disableTransformers = undefined;
+    commander.enable = undefined;
+    commander.disable = undefined;
     commander.module = undefined;
   });
 
@@ -63,8 +63,8 @@ describe('Command Line Interface', function () {
     });
   });
 
-  it('when --transformers=let,noStrict given, enables only these transformers', function() {
-    var options = parse(['--transformers', 'let,noStrict']);
+  it('when --enable=let,noStrict given, enables only these transformers', function() {
+    var options = parse(['--enable', 'let,noStrict']);
     expect(options.transformers).to.deep.equal({
       classes: false,
       stringTemplates: false,
@@ -79,14 +79,14 @@ describe('Command Line Interface', function () {
     });
   });
 
-  it('when --transformers=unknown given, raises error', function() {
+  it('when --enable=unknown given, raises error', function() {
     expect(function() {
-      parse(['--transformers', 'unknown']);
+      parse(['--enable', 'unknown']);
     }).to.throw('Unknown transformer "unknown".');
   });
 
-  it('when --disable-transformers=let,noStrict given, disables the specified transformers', function() {
-    var options = parse(['--disable-transformers', 'let,noStrict']);
+  it('when --disable=let,noStrict given, disables the specified transformers', function() {
+    var options = parse(['--disable', 'let,noStrict']);
     expect(options.transformers).to.deep.equal({
       classes: true,
       stringTemplates: true,
@@ -101,16 +101,16 @@ describe('Command Line Interface', function () {
     });
   });
 
-  it('when --disable-transformers=unknown given, raises error', function() {
+  it('when --disable=unknown given, raises error', function() {
     expect(function() {
-      parse(['--disable-transformers', 'unknown']);
+      parse(['--disable', 'unknown']);
     }).to.throw('Unknown transformer "unknown".');
   });
 
-  it('when --transforms and --disable-transformers used together, raises error', function() {
+  it('when --enable and --disable used together, raises error', function() {
     expect(function() {
-      parse(['--transformers', 'let', '--disable-transformers', 'let']);
-    }).to.throw('Options --transformers and --disable-transformers can not be used together.');
+      parse(['--enable', 'let', '--disable', 'let']);
+    }).to.throw('Options --enable and --disable can not be used together.');
   });
 
   it('when --module=commonjs given, enables CommonJS import/export transformers', function() {

--- a/test/parse-command-line-options.js
+++ b/test/parse-command-line-options.js
@@ -1,0 +1,126 @@
+var expect = require('chai').expect;
+var commander = require('commander');
+var parseCommandLineOptions = require('./../lib/parse-command-line-options.js');
+
+function parse(argv) {
+  return parseCommandLineOptions(['node', 'script.js'].concat(argv));
+}
+
+describe('Command Line Interface', function () {
+  // Command line parser uses commander which has global state.
+  // To be able to test different command-line combinations,
+  // we'll need to reset the state between tests.
+  beforeEach(function() {
+    commander.outFile = undefined;
+    commander.classes = true;
+    commander.transformers = undefined;
+    commander.module = undefined;
+  });
+
+  it('by default reads STDIN and writes to STDOUT', function() {
+    var options = parse([]);
+    expect(options.inFile).to.equal(undefined);
+    expect(options.outFile).to.equal(undefined);
+  });
+
+  it('when existing <filename> given reads <filename> and writes to STDOUT', function() {
+    var options = parse(['lib/io.js']);
+    expect(options.inFile).to.equal('lib/io.js');
+    expect(options.outFile).to.equal(undefined);
+  });
+
+  it('when not-existing <filename> given raises error', function() {
+    expect(function() {
+      parse(['missing.js']);
+    }).to.throw('File missing.js does not exist.')
+  });
+
+  it('when more than one <filename> given raises error', function() {
+    expect(function() {
+      parse(['lib/io.js', 'lib/transformer.js']);
+    }).to.throw('Only one input file allowed, but 2 given instead.')
+  });
+
+  it('when --out-file <filename> given writes <filename> and reads STDIN', function() {
+    var options = parse(['--out-file', 'some/file.js']);
+    expect(options.inFile).to.equal(undefined);
+    expect(options.outFile).to.equal('some/file.js');
+  });
+
+  it('by default enables all transformers except CommonJS import/export', function() {
+    var options = parse([]);
+    expect(options.transformers).to.deep.equal({
+      classes: true,
+      stringTemplates: true,
+      arrowFunctions: true,
+      let: true,
+      defaultArguments: true,
+      objectMethods: true,
+      objectShorthands: true,
+      noStrict: true,
+      importCommonjs: false,
+      exportCommonjs: false,
+    });
+  });
+
+  it('when --no-classes given, enables all transformers except classes', function() {
+    var options = parse(['--no-classes']);
+    expect(options.transformers).to.deep.equal({
+      classes: false,
+      stringTemplates: true,
+      arrowFunctions: true,
+      let: true,
+      defaultArguments: true,
+      objectMethods: true,
+      objectShorthands: true,
+      noStrict: true,
+      importCommonjs: false,
+      exportCommonjs: false,
+    });
+  });
+
+  it('when --transformers=let,noStrict given, enables only these transformers', function() {
+    var options = parse(['--transformers', 'let,noStrict']);
+    expect(options.transformers).to.deep.equal({
+      classes: false,
+      stringTemplates: false,
+      arrowFunctions: false,
+      let: true,
+      defaultArguments: false,
+      objectMethods: false,
+      objectShorthands: false,
+      noStrict: true,
+      importCommonjs: false,
+      exportCommonjs: false,
+    });
+  });
+
+  it('when --transformers=unknown given, raises error', function() {
+    expect(function() {
+      parse(['--transformers', 'unknown']);
+    }).to.throw('Unknown transformer "unknown".');
+  });
+
+  it('when --module=commonjs given, enables CommonJS import/export transformers', function() {
+    var options = parse(['--module', 'commonjs']);
+    expect(options.transformers).to.deep.equal({
+      classes: true,
+      stringTemplates: true,
+      arrowFunctions: true,
+      let: true,
+      defaultArguments: true,
+      objectMethods: true,
+      objectShorthands: true,
+      noStrict: true,
+      importCommonjs: true,
+      exportCommonjs: true,
+    });
+  });
+
+  it('when --module=unknown given, raises error', function() {
+    expect(function() {
+      parse(['--module', 'unknown']);
+    }).to.throw('Unsupported module system "unknown".');
+  });
+
+});

--- a/test/parse-command-line-options.js
+++ b/test/parse-command-line-options.js
@@ -50,30 +50,30 @@ describe('Command Line Interface', function () {
   it('by default enables all transforms', function() {
     var options = parse([]);
     expect(options.transformers).to.deep.equal({
-      classes: true,
-      stringTemplates: true,
-      arrowFunctions: true,
-      let: true,
-      defaultArguments: true,
-      objectMethods: true,
-      objectShorthands: true,
-      noStrict: true,
-      commonjs: true,
+      'class': true,
+      'template': true,
+      'arrow': true,
+      'let': true,
+      'default-param': true,
+      'obj-method': true,
+      'obj-shorthand': true,
+      'no-strict': true,
+      'commonjs': true,
     });
   });
 
-  it('when --enable=let,noStrict,commonjs given, enables only these transformers', function() {
-    var options = parse(['--enable', 'let,noStrict,commonjs']);
+  it('when --enable=let,no-strict,commonjs given, enables only these transformers', function() {
+    var options = parse(['--enable', 'let,no-strict,commonjs']);
     expect(options.transformers).to.deep.equal({
-      classes: false,
-      stringTemplates: false,
-      arrowFunctions: false,
-      let: true,
-      defaultArguments: false,
-      objectMethods: false,
-      objectShorthands: false,
-      noStrict: true,
-      commonjs: true,
+      'class': false,
+      'template': false,
+      'arrow': false,
+      'let': true,
+      'default-param': false,
+      'obj-method': false,
+      'obj-shorthand': false,
+      'no-strict': true,
+      'commonjs': true,
     });
   });
 
@@ -83,18 +83,18 @@ describe('Command Line Interface', function () {
     }).to.throw('Unknown transformer "unknown".');
   });
 
-  it('when --disable=let,noStrict,commonjs given, disables the specified transformers', function() {
-    var options = parse(['--disable', 'let,noStrict,commonjs']);
+  it('when --disable=let,no-strict,commonjs given, disables the specified transformers', function() {
+    var options = parse(['--disable', 'let,no-strict,commonjs']);
     expect(options.transformers).to.deep.equal({
-      classes: true,
-      stringTemplates: true,
-      arrowFunctions: true,
-      let: false,
-      defaultArguments: true,
-      objectMethods: true,
-      objectShorthands: true,
-      noStrict: false,
-      commonjs: false,
+      'class': true,
+      'template': true,
+      'arrow': true,
+      'let': false,
+      'default-param': true,
+      'obj-method': true,
+      'obj-shorthand': true,
+      'no-strict': false,
+      'commonjs': false,
     });
   });
 

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var transformer = new Transformer({arrowFunctions: true});
+var transformer = new Transformer({arrow: true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/classes.js
+++ b/test/transformation/classes.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var transformer = new Transformer({classes: true});
+var transformer = new Transformer({class: true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/comments.js
+++ b/test/transformation/comments.js
@@ -9,8 +9,7 @@ var transformer = new Transformer({
   objectMethods: true,
   objectShorthands: true,
   noStrict: true,
-  importCommonjs: true,
-  exportCommonjs: true,
+  commonjs: true,
 });
 
 function test(script) {

--- a/test/transformation/comments.js
+++ b/test/transformation/comments.js
@@ -1,15 +1,15 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
 var transformer = new Transformer({
-  classes: true,
-  stringTemplates: true,
-  arrowFunctions: true,
-  let: true,
-  defaultArguments: true,
-  objectMethods: true,
-  objectShorthands: true,
-  noStrict: true,
-  commonjs: true,
+  'class': true,
+  'template': true,
+  'arrow': true,
+  'let': true,
+  'default-param': true,
+  'obj-method': true,
+  'obj-shorthand': true,
+  'no-strict': true,
+  'commonjs': true,
 });
 
 function test(script) {

--- a/test/transformation/default-arguments.js
+++ b/test/transformation/default-arguments.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var transformer = new Transformer({defaultArguments: true});
+var transformer = new Transformer({'default-param': true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/export-commonjs.js
+++ b/test/transformation/export-commonjs.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var transformer = new Transformer({exportCommonjs: true});
+var transformer = new Transformer({commonjs: true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/import-commonjs.js
+++ b/test/transformation/import-commonjs.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var transformer = new Transformer({importCommonjs: true});
+var transformer = new Transformer({commonjs: true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/no-strict.js
+++ b/test/transformation/no-strict.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var transformer = new Transformer({noStrict: true});
+var transformer = new Transformer({'no-strict': true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/object-methods.js
+++ b/test/transformation/object-methods.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var transformer = new Transformer({objectMethods: true});
+var transformer = new Transformer({'obj-method': true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/object-shorthands.js
+++ b/test/transformation/object-shorthands.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var transformer = new Transformer({objectShorthands: true});
+var transformer = new Transformer({'obj-shorthand': true});
 
 function test(script) {
   return transformer.run(script);

--- a/test/transformation/template-string.js
+++ b/test/transformation/template-string.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect;
 var Transformer = require('./../../lib/transformer');
-var transformer = new Transformer({stringTemplates: true});
+var transformer = new Transformer({'template': true});
 
 function test(script) {
   return transformer.run(script);


### PR DESCRIPTION
Generalized command line options that deal with enabling/disabling transforms. Removed specific options for Classes and CommonJS transforms, instead accomplishing the same with generic options that can be used to enable/disable any transform.

Simplified the names of all the transform names, and documented them in `--help` output, so one can now actually use them from command line without having to browse the source of Lebab to figure them out.

- Rename `--transformers` option to `--enable`
- Add `--disable` option to disable particular transforms
- Remove `--no-classes` (one can now instead `--disable=class`)
- Remove `--module=commonjs` and enable CommonJS transform by default (if needed one can `--disabe=commonjs`). The two transforms `importCommonjs` and `exportCommonjs` are now combined into a single `commonjs` transform.

Added unit tests for command line options parser.