### PR TITLE
Do not transform object methods to arrow functions

### DIFF
--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import estraverse from 'estraverse';
 import ArrowFunctionExpression from './../syntax/arrow-function-expression.js';
 
@@ -26,16 +27,17 @@ function isFunctionConvertableToArrow(node, parent) {
 }
 
 function hasThis(ast) {
-  return hasInFunctionBody(ast, node => node.type === 'ThisExpression');
+  return hasInFunctionBody(ast, {type: 'ThisExpression'});
 }
 
 function hasArguments(ast) {
-  return hasInFunctionBody(ast, node => node.type === 'Identifier' && node.name === 'arguments');
+  return hasInFunctionBody(ast, {type: 'Identifier', name: 'arguments'});
 }
 
-// Returns true when predicate matches any node in given function body,
+// Returns true when pattern matches any node in given function body,
 // excluding any nested functions
-function hasInFunctionBody(ast, predicate) {
+function hasInFunctionBody(ast, pattern) {
+  const predicate = _.matches(pattern);
   let found = false;
 
   estraverse.traverse(ast, {

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -8,8 +8,8 @@ export default
     });
   }
 
-function callBackToArrow(node) {
-  if (isFunctionConvertableToArrow(node)) {
+function callBackToArrow(node, parent) {
+  if (isFunctionConvertableToArrow(node, parent)) {
     return new ArrowFunctionExpression({
       body: extractArrowBody(node.body),
       params: node.params,
@@ -19,8 +19,9 @@ function callBackToArrow(node) {
   }
 }
 
-function isFunctionConvertableToArrow(node) {
+function isFunctionConvertableToArrow(node, parent) {
   return node.type === 'FunctionExpression' &&
+    parent.type !== 'Property' &&
     !node.id &&
     !node.generator &&
     !hasThis(node.body) &&

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -20,6 +20,7 @@ export default function (ast) {
 function isFunctionConvertableToArrow(node, parent) {
   return node.type === 'FunctionExpression' &&
     parent.type !== 'Property' &&
+    parent.type !== 'MethodDefinition' &&
     !node.id &&
     !node.generator &&
     !hasThis(node.body) &&

--- a/src/transformation/arrow-functions.js
+++ b/src/transformation/arrow-functions.js
@@ -1,22 +1,19 @@
 import estraverse from 'estraverse';
 import ArrowFunctionExpression from './../syntax/arrow-function-expression.js';
 
-export default
-  function (ast) {
-    estraverse.replace(ast, {
-      enter: callBackToArrow
-    });
-  }
-
-function callBackToArrow(node, parent) {
-  if (isFunctionConvertableToArrow(node, parent)) {
-    return new ArrowFunctionExpression({
-      body: extractArrowBody(node.body),
-      params: node.params,
-      defaults: node.defaults,
-      rest: node.rest,
-    });
-  }
+export default function (ast) {
+  estraverse.replace(ast, {
+    enter(node, parent) {
+      if (isFunctionConvertableToArrow(node, parent)) {
+        return new ArrowFunctionExpression({
+          body: extractArrowBody(node.body),
+          params: node.params,
+          defaults: node.defaults,
+          rest: node.rest,
+        });
+      }
+    }
+  });
 }
 
 function isFunctionConvertableToArrow(node, parent) {

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -109,4 +109,12 @@ describe('Callback to Arrow transformation', function () {
     expectNoChange('({foo: function() {}});');
   });
 
+  it('should not convert class methods', function () {
+    expectNoChange(
+      'class Foo {\n' +
+      '  bar() {}\n' +
+      '}'
+    );
+  });
+
 });

--- a/test/transformation/arrow-functions.js
+++ b/test/transformation/arrow-functions.js
@@ -104,4 +104,9 @@ describe('Callback to Arrow transformation', function () {
     expectNoChange('a(function () { if (x) foo(arguments); });');
   });
 
+  it('should not convert object methods', function () {
+    expectNoChange('({foo() {}});');
+    expectNoChange('({foo: function() {}});');
+  });
+
 });


### PR DESCRIPTION
And some additional cleanup of arrow transform.

Solves one of the issues in #90.