### PR TITLE
Fix <0.12 Node support when used as a module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
+require('babel/polyfill');
 exports.Transformer = require('./lib/transformer');


### PR DESCRIPTION
Support for Node versions <0.12 was fixed in e6c5a6ae0557fb718b8f2fefb17091b9db411a93, but that was only for when using Lebab in the command line.

This fix adds the same polyfill when Lebab is required as a module.