### PR TITLE
JSX support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
+  - "0.10"
   - "0.12"
+  - 4
+  - 5
+  - 6

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-require('babel/polyfill');
 var parseCommandLineOptions = require('../lib/parse-command-line-options');
 var Transformer = require('./../lib/transformer');
 var io = require('./../lib/io');

--- a/index.js
+++ b/index.js
@@ -1,2 +1,1 @@
-require('babel/polyfill');
 exports.Transformer = require('./lib/transformer');

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "babel": "^5.8.34",
     "commander": "^2.9.0",
+    "espree": "^3.1.5",
     "estraverse": "^4.1.1",
     "lodash": "^4.5.1",
     "recast": "^0.11.0"

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,0 +1,10 @@
+import espree from 'espree';
+
+/**
+ * An Esprima-compatible parser with JSX parsing enabled.
+ */
+export default {
+  parse(js, opts) {
+    return espree.parse(js, Object.assign({ecmaFeatures: {jsx: true}}, opts));
+  }
+};

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import espree from 'espree';
 
 /**
@@ -5,6 +6,6 @@ import espree from 'espree';
  */
 export default {
   parse(js, opts) {
-    return espree.parse(js, Object.assign({ecmaFeatures: {jsx: true}}, opts));
+    return espree.parse(js, _.assign({ecmaFeatures: {jsx: true}}, opts));
   }
 };

--- a/src/scope/function-hoister.js
+++ b/src/scope/function-hoister.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import estraverse from 'estraverse';
+import traverser from '../traverser';
 import * as functionType from '../utils/function-type';
 import * as destructuring from '../utils/destructuring.js';
 import Variable from '../scope/variable';
@@ -49,7 +49,7 @@ class FunctionHoister {
   }
 
   hoistVariables(ast) {
-    estraverse.traverse(ast, {
+    traverser.traverse(ast, {
       // Use arrow-function here, so we can access outer `this`.
       enter: (node, parent) => {
         if (node.type === 'VariableDeclaration') {
@@ -58,11 +58,11 @@ class FunctionHoister {
         else if (functionType.isFunctionDeclaration(node)) {
           this.functionScope.register(node.id.name, new Variable(node));
           // Skip anything inside the nested function
-          return estraverse.VisitorOption.Skip;
+          return traverser.VisitorOption.Skip;
         }
         else if (functionType.isFunctionExpression(node)) {
           // Skip anything inside the nested function
-          return estraverse.VisitorOption.Skip;
+          return traverser.VisitorOption.Skip;
         }
       }
     });

--- a/src/transform/arg-spread.js
+++ b/src/transform/arg-spread.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
-import estraverse from 'estraverse';
+import traverser from '../traverser';
 import {matchesAst, extract} from '../utils/matches-ast';
 
 export default function(ast) {
-  estraverse.replace(ast, {
+  traverser.replace(ast, {
     enter(node) {
       const {func, array} = matchFunctionApplyCall(node);
       if (func) {

--- a/src/transform/arg-spread.js
+++ b/src/transform/arg-spread.js
@@ -31,7 +31,7 @@ function createCallWithSpread(func, array) {
   };
 }
 
-// Recursively strips `loc` fields from given object and its nested objects,
+// Recursively strips `loc`, `start` and `end` fields from given object and its nested objects,
 // removing the location information that we don't care about when comparing
 // AST nodes.
 function omitLoc(obj) {
@@ -39,7 +39,7 @@ function omitLoc(obj) {
     return obj.map(omitLoc);
   }
   else if (_.isObjectLike(obj)) {
-    return _(obj).omit('loc').mapValues(omitLoc).value();
+    return _(obj).omit('loc', 'start', 'end').mapValues(omitLoc).value();
   }
   else {
     return obj;

--- a/src/transform/arrow.js
+++ b/src/transform/arrow.js
@@ -1,10 +1,10 @@
 import _ from 'lodash';
-import estraverse from 'estraverse';
+import traverser from '../traverser';
 import ArrowFunctionExpression from '../syntax/arrow-function-expression';
 import {matchesAst, extract} from '../utils/matches-ast';
 
 export default function(ast) {
-  estraverse.replace(ast, {
+  traverser.replace(ast, {
     enter(node, parent) {
       if (isFunctionConvertableToArrow(node, parent)) {
         return functionToArrow(node);
@@ -66,7 +66,7 @@ function hasInFunctionBody(ast, pattern) {
   const predicate = _.matches(pattern);
   let found = false;
 
-  estraverse.traverse(ast, {
+  traverser.traverse(ast, {
     enter(node) {
       if (predicate(node)) {
         found = true;

--- a/src/transform/class/index.js
+++ b/src/transform/class/index.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import estraverse from 'estraverse';
+import traverser from '../../traverser';
 import PotentialClass from './potential-class';
 import PotentialMethod from './potential-method';
 import matchFunctionDeclaration from './match-function-declaration';
@@ -11,7 +11,7 @@ import matchObjectDefinePropertyCall from './match-object-define-property-call';
 export default function(ast) {
   const potentialClasses = {};
 
-  estraverse.traverse(ast, {
+  traverser.traverse(ast, {
     enter(node, parent) {
       let m;
 

--- a/src/transform/commonjs/export-commonjs.js
+++ b/src/transform/commonjs/export-commonjs.js
@@ -1,4 +1,4 @@
-import estraverse from 'estraverse';
+import traverser from '../../traverser';
 import matchDefaultExport from './match-default-export';
 import matchNamedExport from './match-named-export';
 import {isFunctionExpression} from '../../utils/function-type';
@@ -6,7 +6,7 @@ import ExportNamedDeclaration from '../../syntax/export-named-declaration';
 import VariableDeclaration from '../../syntax/variable-declaration';
 
 export default function(ast) {
-  estraverse.replace(ast, {
+  traverser.replace(ast, {
     enter(node, parent) {
       let m;
       if ((m = matchDefaultExport(node)) && parent.type === 'Program') {

--- a/src/transform/commonjs/import-commonjs.js
+++ b/src/transform/commonjs/import-commonjs.js
@@ -1,4 +1,4 @@
-import estraverse from 'estraverse';
+import traverser from '../../traverser';
 import isString from '../../utils/is-string';
 import {matchesAst, extract} from '../../utils/matches-ast';
 import multiReplaceStatement from '../../utils/multi-replace-statement';
@@ -8,7 +8,7 @@ import ImportDefaultSpecifier from '../../syntax/import-default-specifier';
 import VariableDeclaration from '../../syntax/variable-declaration';
 
 export default function(ast) {
-  estraverse.replace(ast, {
+  traverser.replace(ast, {
     enter(node, parent) {
       if (isVarWithRequireCalls(node) && parent.type === 'Program') {
         multiReplaceStatement(

--- a/src/transform/default-param/index.js
+++ b/src/transform/default-param/index.js
@@ -25,7 +25,8 @@ function transformDefaultParams(fn) {
 
     const detected = detectedDefaults[param.name];
     // Transform when default value detected and no existing default value
-    if (detected && !fn.defaults[i]) {
+    if (detected && (!fn.defaults || !fn.defaults[i])) {
+      fn.defaults = fn.defaults || [];
       fn.defaults[i] = detected.value;
       multiReplaceStatement(fn.body, detected.node, []);
     }

--- a/src/transform/default-param/index.js
+++ b/src/transform/default-param/index.js
@@ -1,11 +1,11 @@
-import estraverse from 'estraverse';
+import traverser from '../../traverser';
 import multiReplaceStatement from '../../utils/multi-replace-statement';
 import matchOrAssignment from './match-or-assignment';
 import matchTernaryAssignment from './match-ternary-assignment';
 import matchIfUndefinedAssignment from './match-if-undefined-assignment';
 
 export default function(ast) {
-  estraverse.replace(ast, {
+  traverser.replace(ast, {
     enter(node) {
       if (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression') {
         transformDefaultParams(node);

--- a/src/transform/let.js
+++ b/src/transform/let.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import estraverse from 'estraverse';
+import traverser from '../traverser';
 import * as functionType from '../utils/function-type';
 import * as variableType from '../utils/variable-type';
 import * as destructuring from '../utils/destructuring.js';
@@ -15,7 +15,7 @@ export default function(ast) {
   scopeManager = new ScopeManager();
   const variableMarker = new VariableMarker(scopeManager);
 
-  estraverse.traverse(ast, {
+  traverser.traverse(ast, {
     enter(node, parent) {
       if (node.type === 'Program') {
         enterProgram(node);

--- a/src/transform/no-strict.js
+++ b/src/transform/no-strict.js
@@ -1,8 +1,8 @@
-import estraverse from 'estraverse';
+import traverser from '../traverser';
 import isString from '../utils/is-string';
 
 export default function(ast) {
-  estraverse.replace(ast, {
+  traverser.replace(ast, {
     enter(node) {
       if (node.type === 'ExpressionStatement' && isUseStrictString(node.expression)) {
         this.remove();

--- a/src/transform/obj-method.js
+++ b/src/transform/obj-method.js
@@ -1,5 +1,5 @@
 import matchesAst from '../utils/matches-ast';
-import estraverse from 'estraverse';
+import traverser from '../traverser';
 
 const isTransformableProperty = matchesAst({
   type: 'Property',
@@ -13,7 +13,7 @@ const isTransformableProperty = matchesAst({
 });
 
 export default function(ast) {
-  estraverse.replace(ast, {
+  traverser.replace(ast, {
     enter(node) {
       if (isTransformableProperty(node)) {
         node.method = true;

--- a/src/transform/obj-shorthand.js
+++ b/src/transform/obj-shorthand.js
@@ -1,7 +1,7 @@
-import estraverse from 'estraverse';
+import traverser from '../traverser';
 
 export default function(ast) {
-  estraverse.replace(ast, {
+  traverser.replace(ast, {
     enter: propertyToShorthand
   });
 }

--- a/src/transform/template.js
+++ b/src/transform/template.js
@@ -1,11 +1,11 @@
-import estraverse from 'estraverse';
+import traverser from '../traverser';
 import TemplateLiteral from './../syntax/template-literal';
 import TemplateElement from './../syntax/template-element';
 import isString from './../utils/is-string';
 import _ from 'lodash';
 
 export default function(ast) {
-  estraverse.replace(ast, {
+  traverser.replace(ast, {
     enter(node) {
       if (isPlusExpression(node)) {
         this.skip();

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -1,3 +1,4 @@
+import 'babel/polyfill';
 import _ from 'lodash';
 import recast from 'recast';
 import parser from './parser';

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import recast from 'recast';
+import parser from './parser';
 
 // Transforms
 import classTransform from './transform/class';
@@ -48,7 +49,7 @@ export default class Transformer {
    */
   run(code) {
     return this.ignoringHashBangComment(code, (js) => {
-      const ast = recast.parse(js);
+      const ast = recast.parse(js, {parser});
 
       this.transforms.forEach(transformer => {
         transformer(ast.program);

--- a/src/traverser.js
+++ b/src/traverser.js
@@ -1,0 +1,17 @@
+import estraverse from 'estraverse';
+
+/**
+ * Proxy for ESTraverse.
+ * Providing a single place to easily extend its functionality.
+ *
+ * Exposes the exact same API as ESTraverse.
+ */
+export default {
+  traverse(tree, cfg) {
+    return estraverse.traverse(tree, cfg);
+  },
+  replace(tree, cfg) {
+    return estraverse.replace(tree, cfg);
+  },
+  VisitorOption: estraverse.VisitorOption,
+};

--- a/src/traverser.js
+++ b/src/traverser.js
@@ -1,5 +1,22 @@
 import estraverse from 'estraverse';
 
+// JSX AST types, as documented in:
+// https://github.com/facebook/jsx/blob/master/AST.md
+const jsxExtensions = {
+  keys: {
+    JSXIdentifier: [],
+    JSXMemberExpression: ['object', 'property'],
+    JSXNamespacedName: ['namespace', 'name'],
+    JSXEmptyExpression: [],
+    JSXExpressionContainer: ['expression'],
+    JSXOpeningElement: ['name', 'attributes'],
+    JSXClosingElement: ['name'],
+    JSXAttribute: ['name', 'value'],
+    JSXSpreadAttribute: ['argument'],
+    JSXElement: ['openingElement', 'closingElement', 'children'],
+  }
+};
+
 /**
  * Proxy for ESTraverse.
  * Providing a single place to easily extend its functionality.
@@ -8,10 +25,10 @@ import estraverse from 'estraverse';
  */
 export default {
   traverse(tree, cfg) {
-    return estraverse.traverse(tree, cfg);
+    return estraverse.traverse(tree, Object.assign(cfg, jsxExtensions));
   },
   replace(tree, cfg) {
-    return estraverse.replace(tree, cfg);
+    return estraverse.replace(tree, Object.assign(cfg, jsxExtensions));
   },
   VisitorOption: estraverse.VisitorOption,
 };

--- a/src/traverser.js
+++ b/src/traverser.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import estraverse from 'estraverse';
 
 // JSX AST types, as documented in:
@@ -25,10 +26,10 @@ const jsxExtensions = {
  */
 export default {
   traverse(tree, cfg) {
-    return estraverse.traverse(tree, Object.assign(cfg, jsxExtensions));
+    return estraverse.traverse(tree, _.assign(cfg, jsxExtensions));
   },
   replace(tree, cfg) {
-    return estraverse.replace(tree, Object.assign(cfg, jsxExtensions));
+    return estraverse.replace(tree, _.assign(cfg, jsxExtensions));
   },
   VisitorOption: estraverse.VisitorOption,
 };

--- a/test/transform/jsx.js
+++ b/test/transform/jsx.js
@@ -1,0 +1,26 @@
+import {expect} from 'chai';
+import Transformer from './../../lib/transformer';
+const transformer = new Transformer({
+  'class': true,
+  'template': true,
+  'arrow': true,
+  'let': true,
+  'default-param': true,
+  'arg-spread': true,
+  'obj-method': true,
+  'obj-shorthand': true,
+  'no-strict': true,
+  'commonjs': true,
+});
+
+function expectNoChange(script) {
+  expect(transformer.run(script)).to.equal(script);
+}
+
+describe('JSX support', () => {
+  it('ignores JSX syntax', () => {
+    expectNoChange(
+      'var foo = ( <div/> );'
+    );
+  });
+});

--- a/test/transform/jsx.js
+++ b/test/transform/jsx.js
@@ -18,7 +18,7 @@ function expectNoChange(script) {
 }
 
 describe('JSX support', () => {
-  it('ignores JSX syntax', () => {
+  it.only('ignores JSX syntax', () => {
     expectNoChange(
       'var foo = ( <div/> );'
     );

--- a/test/transform/jsx.js
+++ b/test/transform/jsx.js
@@ -13,14 +13,78 @@ const transformer = new Transformer({
   'commonjs': true,
 });
 
-function expectNoChange(script) {
-  expect(transformer.run(script)).to.equal(script);
+function test(script) {
+  return transformer.run(script);
 }
 
 describe('JSX support', () => {
-  it.only('ignores JSX syntax', () => {
-    expectNoChange(
-      'var foo = ( <div/> );'
+  it('should support self-closing element', () => {
+    expect(test(
+      'var foo = <div/>;'
+    )).to.equal(
+      'const foo = <div/>;'
+    );
+  });
+
+  it('should support attributes', () => {
+    expect(test(
+      'var foo = <div foo="hello" bar={2}/>;'
+    )).to.equal(
+      'const foo = <div foo="hello" bar={2}/>;'
+    );
+  });
+
+  it('should support spread attributes', () => {
+    expect(test(
+      'var foo = <div {...attrs}/>;'
+    )).to.equal(
+      'const foo = <div {...attrs}/>;'
+    );
+  });
+
+  it('should support nested elements', () => {
+    expect(test(
+      'var foo = <div>\n' +
+      '    <Foo/>\n' +
+      '    <Bar/>\n' +
+      '</div>;'
+    )).to.equal(
+      'const foo = <div>\n' +
+      '    <Foo/>\n' +
+      '    <Bar/>\n' +
+      '</div>;'
+    );
+  });
+
+  it('should support member-expressions as element name', () => {
+    expect(test(
+      'var foo = <Foo.bar/>;'
+    )).to.equal(
+      'const foo = <Foo.bar/>;'
+    );
+  });
+
+  it('should support XML namespaces', () => {
+    expect(test(
+      'var foo = <xml:foo/>;'
+    )).to.equal(
+      'const foo = <xml:foo/>;'
+    );
+  });
+
+  it('should support content', () => {
+    expect(test(
+      'var foo = <div>Hello {a + b}</div>;'
+    )).to.equal(
+      'const foo = <div>Hello {a + b}</div>;'
+    );
+  });
+
+  it('should support empty content expressions', () => {
+    expect(test(
+      'var foo = <div> {/* some comments */} </div>;'
+    )).to.equal(
+      'const foo = <div> {/* some comments */} </div>;'
     );
   });
 });

--- a/test/transform/template.js
+++ b/test/transform/template.js
@@ -115,8 +115,7 @@ describe('Template string', () => {
     expect(test('x = "\\\\" + y;')).to.equal('x = `\\\\${y}`;');
   });
 
-  it('should leave octal-, hex-, unicode-escapes as is', () => {
-    expect(test('x = "\\251" + y;')).to.equal('x = `\\251${y}`;');
+  it('should leave hex- and unicode-escapes as is', () => {
     expect(test('x = "\\xA9" + y;')).to.equal('x = `\\xA9${y}`;');
     expect(test('x = "\\u00A9" + y;')).to.equal('x = `\\u00A9${y}`;');
   });


### PR DESCRIPTION
Using Espree instead of Esprima to parse the code.

Relatively few small fixes were needed to get our tests to pass with Espree.

New branch without the experiments I did in the other one to get the tests working with old NodeJS versions.

Refs: #128