### PR TITLE
Add support for static methods

### DIFF
--- a/src/transform/class/index.js
+++ b/src/transform/class/index.js
@@ -4,6 +4,7 @@ import PotentialClass from './potential-class';
 import PotentialMethod from './potential-method';
 import matchFunctionDeclaration from './match-function-declaration';
 import matchFunctionVar from './match-function-var';
+import matchFunctionAssignment from './match-function-assignment';
 import matchPrototypeFunctionAssignment from './match-prototype-function-assignment';
 import matchPrototypeObjectAssignment from './match-prototype-object-assignment';
 import matchObjectDefinePropertyCall from './match-object-define-property-call';
@@ -37,6 +38,17 @@ export default function(ast) {
           parent,
         });
       }
+      else if ((m = matchFunctionAssignment(node))) {
+        if (potentialClasses[m.className]) {
+          potentialClasses[m.className].addMethod(new PotentialMethod({
+            name: m.methodName,
+            methodNode: m.methodNode,
+            fullNode: node,
+            parent,
+            static: true
+          }));
+        }
+      }
       else if ((m = matchPrototypeFunctionAssignment(node))) {
         if (potentialClasses[m.className]) {
           potentialClasses[m.className].addMethod(new PotentialMethod({
@@ -44,6 +56,7 @@ export default function(ast) {
             methodNode: m.methodNode,
             fullNode: node,
             parent,
+            static: false
           }));
         }
       }
@@ -55,6 +68,7 @@ export default function(ast) {
               methodNode: method.methodNode,
               fullNode: node,
               parent,
+              static: false
             }));
           });
         }
@@ -68,6 +82,7 @@ export default function(ast) {
               fullNode: node,
               parent,
               kind: desc.kind,
+              static: false
             }));
           });
         }

--- a/src/transform/class/match-function-assignment.js
+++ b/src/transform/class/match-function-assignment.js
@@ -1,0 +1,36 @@
+import {matchesAst, extract} from '../../utils/matches-ast';
+
+/**
+ * Matches: <className>.<methodName> = function () { ... }
+ *
+ * When node matches returns the extracted fields:
+ *
+ * - className
+ * - methodName
+ * - methodNode
+ *
+ * @param  {Object} node
+ * @return {Object}
+ */
+export default matchesAst({
+  type: 'ExpressionStatement',
+  expression: {
+    type: 'AssignmentExpression',
+    left: {
+      type: 'MemberExpression',
+      computed: false,
+      object: {
+        type: 'Identifier',
+        name: extract('className')
+      },
+      property: {
+        type: 'Identifier',
+        name: extract('methodName')
+      }
+    },
+    operator: '=',
+    right: extract('methodNode', {
+      type: 'FunctionExpression'
+    })
+  }
+});

--- a/src/transform/class/potential-method.js
+++ b/src/transform/class/potential-method.js
@@ -12,13 +12,15 @@ class PotentialMethod {
    *   @param {Object} cfg.fullNode
    *   @param {Object} cfg.parent
    *   @param {String} cfg.kind Either 'get' or 'set' (optional)
+   *   @param {boolean} cfg.static
    */
-  constructor({name, methodNode, fullNode, parent, kind}) {
-    this.name = name;
-    this.methodNode = methodNode;
-    this.fullNode = fullNode;
-    this.parent = parent;
-    this.kind = kind || 'method';
+  constructor(cfg) {
+    this.name = cfg.name;
+    this.methodNode = cfg.methodNode;
+    this.fullNode = cfg.fullNode;
+    this.parent = cfg.parent;
+    this.kind = cfg.kind || 'method';
+    this.static = cfg.static;
   }
 
   /**
@@ -50,7 +52,7 @@ class PotentialMethod {
         expression: false,
       },
       kind: this.kind,
-      static: false,
+      static: this.static,
       comments: this.fullNode && this.fullNode.comments,
     };
   }

--- a/test/transform/class.js
+++ b/test/transform/class.js
@@ -32,6 +32,20 @@ describe('Classes', () => {
     );
   });
 
+  it('should convert static function declarations with assignment to static class methods', () => {
+    expect(test(
+      'function MyClass() {\n' +
+      '}\n' +
+      'MyClass.method = function(a, b) {\n' +
+      '};'
+    )).to.equal(
+      'class MyClass {\n' +
+      '  static method(a, b) {\n' +
+      '  }\n' +
+      '}'
+    );
+  });
+
   it('should convert function variables with prototype assignment to class', () => {
     expect(test(
       'var MyClass = function() {\n' +


### PR DESCRIPTION
Add support for static methods, e.g.

Input:
```
function MyClass() {
}
MyClass.method = function(a, b) {
};
```
Output:
```
class MyClass {
  static method(a, b) {
  }
}
```