### PR TITLE
Add namespace removing transform

### DIFF
--- a/src/transform/no-namespace.js
+++ b/src/transform/no-namespace.js
@@ -1,0 +1,166 @@
+import traverser from '../traverser';
+import {matchesAst, extract} from '../utils/matches-ast';
+// import ArrowFunctionExpression from '../syntax/arrow-function-expression';
+
+export default function(ast) {
+  traverser.replace(ast, {
+    enter(node) {
+      var m;
+      if ((m = isNamespacedClass(node))) {
+        return {
+          type: 'FunctionExpression',
+          id: m.className,
+          params: m.params,
+          body: m.body
+        };
+      }
+      else if ((m = isNamespacedMethod(node))) {
+        return {
+          type: 'ExpressionStatement',
+          expression: {
+            type: 'AssignmentExpression',
+            operator: '=',
+            left: {
+              type: 'MemberExpression',
+              object: {
+                type: 'MemberExpression',
+                object: {
+                  type: 'Identifier',
+                  name: m.className
+                },
+                property: {
+                  type: 'Identifier',
+                  name: 'prototype'
+                }
+              },
+              property: {
+                type: 'Identifier',
+                name: m.methodName
+              }
+            },
+            right: {
+              type: 'FunctionExpression',
+              id: null,
+              params: m.params,
+              body: m.body
+            }
+          }
+        };
+      }
+      else if ((m = isNamespacedStaticMethod(node))) {
+        return {
+          type: 'ExpressionStatement',
+          expression: {
+            type: 'AssignmentExpression',
+            operator: '=',
+            left: {
+              type: 'MemberExpression',
+              object: {
+                type: 'Identifier',
+                name: m.className
+              },
+              property: {
+                type: 'Identifier',
+                name: m.methodName
+              }
+            },
+            right: {
+              type: 'FunctionExpression',
+              id: null,
+              params: m.params,
+              body: m.body
+            }
+          }
+        };
+      }
+    }
+  });
+}
+
+var isNamespacedClass = matchesAst({
+  type: 'ExpressionStatement',
+  expression: {
+    type: 'AssignmentExpression',
+    left: {
+      type: 'MemberExpression',
+      computed: false,
+      property: ast => {
+        if (ast.type === 'Identifier' && ast.name !== 'prototype' && ast.name[0] === ast.name[0].toUpperCase()) {
+          return {className: ast.name};
+        }
+      }
+    },
+    operator: '=',
+    right: extract('methodNode', {
+      type: 'FunctionExpression',
+      params: extract('params'),
+      body: extract('body')
+    })
+  }
+});
+
+var isNamespacedMethod = matchesAst({
+  type: 'ExpressionStatement',
+  expression: {
+    type: 'AssignmentExpression',
+    left: {
+      type: 'MemberExpression',
+      computed: false,
+      object: {
+        type: 'MemberExpression',
+        computed: false,
+        object: {
+          type: 'MemberExpression',
+          computed: false,
+          property: {
+            type: 'Identifier',
+            name: extract('className')
+          }
+        },
+        property: {
+          type: 'Identifier',
+          name: 'prototype'
+        }
+      },
+      property: {
+        type: 'Identifier',
+        name: extract('methodName')
+      }
+    },
+    operator: '=',
+    right: extract('methodNode', {
+      type: 'FunctionExpression',
+      params: extract('params'),
+      body: extract('body')
+    })
+  }
+});
+
+var isNamespacedStaticMethod = matchesAst({
+  type: 'ExpressionStatement',
+  expression: {
+    type: 'AssignmentExpression',
+    left: {
+      type: 'MemberExpression',
+      computed: false,
+      object: {
+        type: 'MemberExpression',
+        computed: false,
+        property: {
+          type: 'Identifier',
+          name: extract('className')
+        }
+      },
+      property: {
+        type: 'Identifier',
+        name: extract('methodName')
+      }
+    },
+    operator: '=',
+    right: extract('methodNode', {
+      type: 'FunctionExpression',
+      params: extract('params'),
+      body: extract('body')
+    })
+  }
+});

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -13,6 +13,7 @@ import argSpreadTransform from './transform/arg-spread';
 import objMethodTransform from './transform/obj-method';
 import objShorthandTransform from './transform/obj-shorthand';
 import noStrictTransform from './transform/no-strict';
+import noNamespaceTransform from './transform/no-namespace';
 import commonjsTransform from './transform/commonjs';
 
 const transformsMap = {
@@ -25,6 +26,7 @@ const transformsMap = {
   'obj-method': objMethodTransform,
   'obj-shorthand': objShorthandTransform,
   'no-strict': noStrictTransform,
+  'no-namespace': noNamespaceTransform,
   'commonjs': commonjsTransform,
 };
 

--- a/test/transform/no-namespace.js
+++ b/test/transform/no-namespace.js
@@ -1,0 +1,80 @@
+import {expect} from 'chai';
+import Transformer from './../../lib/transformer';
+const transformer = new Transformer({'no-namespace': true});
+
+function test(script) {
+  return transformer.run(script);
+}
+
+function expectNoChange(script) {
+  expect(test(script)).to.equal(script);
+}
+
+describe.only('Removal of namespaces', () => {
+  it('should remain non-named functions as-is', () => {
+    expectNoChange(
+      'function MyClass() {\n' +
+      '}'
+    );
+  });
+
+  it('should remove namespace from a namespaced function constructor', () => {
+    expect(test(
+      'MyNamespace.MyClass = function(a, b) {\n' +
+      '};'
+    )).to.equal(
+      'function MyClass(a, b) {\n' +
+      '}'
+    );
+  });
+
+  it('should remove namespace from a namespaced method', () => {
+    expect(test(
+      'MyNamespace.MyClass.prototype.myFunc = function(a, b) {\n' +
+      '};'
+    )).to.equal(
+      'MyClass.prototype.myFunc = function(a, b) {\n' +
+      '};'
+    );
+  });
+
+  it('should remove namespace from a namespaced static method', () => {
+    expect(test(
+      'MyNamespace.MyClass.myFunc = function(a, b) {\n' +
+      '};'
+    )).to.equal(
+      'MyClass.myFunc = function(a, b) {\n' +
+      '};'
+    );
+  });
+
+  it('should remove namespace from a doubly namespaced function constructor', () => {
+    expect(test(
+      'FirstNS.SecondNS.MyClass = function(a, b) {\n' +
+      '};'
+    )).to.equal(
+      'function MyClass(a, b) {\n' +
+      '}'
+    );
+  });
+
+  it('should remove namespace from a doubly namespaced method', () => {
+    expect(test(
+      'FirstNS.SecondNS.MyClass.prototype.myFunc = function(a, b) {\n' +
+      '};'
+    )).to.equal(
+      'MyClass.prototype.myFunc = function(a, b) {\n' +
+      '};'
+    );
+  });
+
+  it('should remove namespace from a doubly namespaced static method', () => {
+    expect(test(
+      'FirstNS.SecondNS.MyClass.myFunc = function(a, b) {\n' +
+      '};'
+    )).to.equal(
+      'MyClass.myFunc = function(a, b) {\n' +
+      '};'
+    );
+  });
+});


### PR DESCRIPTION
Motivation: Updating old JavaScript code to ES6 can often have namespaces ([related issue](https://github.com/mohebifar/lebab/issues/113)). e.g.

```
FirstNS.SecondNS.MyClass = function(a, b) {
};

FirstNS.SecondNS.MyClass.prototype.myFunc = function(a, b) {
};
```

where you would prefer:

```
class MyClass{
  constructor(a, b) {
  }

  myFunc(a, b) {
  }
};
```

My first approach was to introduce this into the class transform, but I believe the approach in this PR separates the concerns a bit better by introducing a transform whose sole job is to remove namespaces.

Unfortunately this introduces an ordering dependency, where you need to run `no-namespace` transform before running the `class` transform. I'd like to hear feedback on this.

The code submitted is really my first hacky attempt, without thorough testing. Hoping this PR generates some interest and maybe some ideas on how to add this pretty handy feature.

Edit: Oh and the `Error: {...} does not match type string` error was super annoying, I eventually commented out `isString.assert(stmt);` in [`recast/lib/printer.js`](https://github.com/benjamn/recast/blob/9d351c27cb981ebd65189b113c9a2aa87bbc560c/lib/printer.js#L1503) because I couldn't tell what was causing it. Maybe you will know :)

Edit: More TODOs: Update usage throughout file, and preserve comments.