### PR TITLE
Add support for object rest and spread operators

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -2,13 +2,13 @@ import _ from 'lodash';
 import espree from 'espree';
 
 /**
- * An Esprima-compatible parser with JSX parsing enabled.
+ * An Esprima-compatible parser with JSX and object rest/spread parsing enabled.
  */
 export default {
   parse(js, opts) {
     return espree.parse(js, _.assign(opts, {
       ecmaVersion: 7,
-      ecmaFeatures: {jsx: true}
+      ecmaFeatures: {jsx: true, experimentalObjectRestSpread: true}
     }));
   }
 };

--- a/src/traverser.js
+++ b/src/traverser.js
@@ -3,19 +3,26 @@ import estraverse from 'estraverse';
 
 // JSX AST types, as documented in:
 // https://github.com/facebook/jsx/blob/master/AST.md
-const jsxExtensions = {
-  keys: {
-    JSXIdentifier: [],
-    JSXMemberExpression: ['object', 'property'],
-    JSXNamespacedName: ['namespace', 'name'],
-    JSXEmptyExpression: [],
-    JSXExpressionContainer: ['expression'],
-    JSXOpeningElement: ['name', 'attributes'],
-    JSXClosingElement: ['name'],
-    JSXAttribute: ['name', 'value'],
-    JSXSpreadAttribute: ['argument'],
-    JSXElement: ['openingElement', 'closingElement', 'children'],
-  }
+const jsxExtensionKeys = {
+  JSXIdentifier: [],
+  JSXMemberExpression: ['object', 'property'],
+  JSXNamespacedName: ['namespace', 'name'],
+  JSXEmptyExpression: [],
+  JSXExpressionContainer: ['expression'],
+  JSXOpeningElement: ['name', 'attributes'],
+  JSXClosingElement: ['name'],
+  JSXAttribute: ['name', 'value'],
+  JSXSpreadAttribute: ['argument'],
+  JSXElement: ['openingElement', 'closingElement', 'children'],
+};
+
+const experimentalExtensionKeys = {
+  ExperimentalRestProperty: ['argument'],
+  ExperimentalSpreadProperty: ['argument'],
+};
+
+const extensions = {
+  keys: _.assign({}, jsxExtensionKeys, experimentalExtensionKeys),
 };
 
 /**
@@ -33,7 +40,7 @@ export default {
    * @return {Object} The transformed tree
    */
   traverse(tree, cfg) {
-    return estraverse.traverse(tree, _.assign(cfg, jsxExtensions));
+    return estraverse.traverse(tree, _.assign(cfg, extensions));
   },
 
   /**
@@ -43,7 +50,7 @@ export default {
    * @return {Object} The transformed tree
    */
   replace(tree, cfg) {
-    return estraverse.replace(tree, _.assign(cfg, jsxExtensions));
+    return estraverse.replace(tree, _.assign(cfg, extensions));
   },
 
   /**

--- a/test/transform/restSpreadTest.js
+++ b/test/transform/restSpreadTest.js
@@ -1,0 +1,20 @@
+import createTestHelpers from '../createTestHelpers';
+const {expectTransform} = createTestHelpers(['let']);
+
+describe('Rest and Spread support', () => {
+  it('should support object rest in destructuring', () => {
+    expectTransform(
+      'var { foo, ...other } = bar;'
+    ).toReturn(
+      'const { foo, ...other } = bar;'
+    );
+  });
+
+  it('should support object spread', () => {
+    expectTransform(
+      'var foo = { bar, ...other };'
+    ).toReturn(
+      'const foo = { bar, ...other };'
+    );
+  });
+});


### PR DESCRIPTION
Before this, I was getting `SyntaxError: Unexpected token ...` in my React code that uses object rest and spread outside of JSX syntax.

Thankfully, espree supports this with the `experimentalObjectRestSpread` option to the parser (thanks to support for it being required by ESLint).

After parsing successfully, estraverse threw with `Error: Unknown node type ExperimentalRestProperty.`, so I added the node types to the traverse in the same way as the JSX node types.