### PR TITLE
use unix-style line endings when printing

### DIFF
--- a/src/Transformer.js
+++ b/src/Transformer.js
@@ -37,7 +37,7 @@ export default class Transformer {
         transformer(ast.program, logger);
       });
 
-      return recast.print(ast).code;
+      return recast.print(ast, {lineTerminator: '\n'}).code;
     });
   }
 


### PR DESCRIPTION
Although I primarily use Windows as my OS, I imagine most JavaScript devs use Unix-style line endings across platforms, as I do.

Without this, running on Windows, lebab changes all the existing Unix line endings to Windows ones.