### PR TITLE
ignore multi-vars in a for loop initializer

### DIFF
--- a/src/transform/multiVar.js
+++ b/src/transform/multiVar.js
@@ -2,7 +2,10 @@ import traverser from '../traverser';
 import multiReplaceStatement from '../utils/multiReplaceStatement';
 import VariableDeclaration from '../syntax/VariableDeclaration';
 
-export default function(ast) {
+let logger;
+
+export default function(ast, loggerInstance) {
+  logger = loggerInstance;
   traverser.traverse(ast, {
     enter(node, parent) {
       if (node.type === 'VariableDeclaration' && node.declarations.length > 1) {
@@ -19,10 +22,15 @@ function splitDeclaration(node, parent) {
     return new VariableDeclaration(node.kind, [declarator]);
   });
 
-  multiReplaceStatement({
-    parent,
-    node,
-    replacements: declNodes,
-    preserveComments: true,
-  });
+  try {
+    multiReplaceStatement({
+      parent,
+      node,
+      replacements: declNodes,
+      preserveComments: true,
+    });
+  }
+  catch (e) {
+    logger.warn(parent, `Unable to replace a multi var statement in a ${parent.type}`, 'multi-var');
+  }
 }

--- a/test/transform/multiVarTest.js
+++ b/test/transform/multiVarTest.js
@@ -1,5 +1,5 @@
 import createTestHelpers from '../createTestHelpers';
-const {expectTransform} = createTestHelpers(['multi-var']);
+const {expectTransform, expectNoChange} = createTestHelpers(['multi-var']);
 
 describe('Multi-var', () => {
   describe('with only one variable per declaration', () => {
@@ -87,6 +87,14 @@ describe('Multi-var', () => {
       ).toReturn(
         'var x;\n' +
         'var /* hello */y=100;'
+      );
+    });
+  });
+
+  describe('in a for loop', () => {
+    it('should not change anything', () => {
+      expectNoChange(
+        'for (var i=0,j=0; i<j; i++) j++;'
       );
     });
   });


### PR DESCRIPTION
Currently, when multi-var encounters a multi var in a for loop initializer, it throws the error from `multiReplaceStatement` and the process terminates.

This change catches the error, logs the warning and lets it continue with the rest of the file(s).