### PR TITLE
Configureable line terminators

### DIFF
--- a/src/Transformer.js
+++ b/src/Transformer.js
@@ -9,9 +9,11 @@ import Logger from './Logger';
 export default class Transformer {
   /**
    * @param {Function[]} transforms List of transforms to perform
+   * @param {String} [eol] Line endings to use in transformed code, defaults to OS default.
    */
-  constructor(transforms = []) {
+  constructor(transforms = [], eol = require('os').EOL) {
     this.transforms = transforms;
+    this.eol = eol;
   }
 
   /**
@@ -37,7 +39,7 @@ export default class Transformer {
         transformer(ast.program, logger);
       });
 
-      return recast.print(ast).code;
+      return recast.print(ast, {lineTerminator: this.eol}).code;
     });
   }
 

--- a/src/parseOptions.js
+++ b/src/parseOptions.js
@@ -33,6 +33,7 @@ program.option('-o, --out-file <file>', 'write output to a file');
 program.option('--replace <dir>', `in-place transform all *.js files in a directory
                          <dir> can also be a single file or a glob pattern`);
 program.option('-t, --transform <a,b,c>', 'one or more transformations to perform', v => v.split(','));
+program.option('--eol <cr|lf|crlf|auto>');
 
 /**
  * Parses and validates command line options from argv.
@@ -50,6 +51,7 @@ export default function parseCommandLineOptions(argv) {
     outFile: program.outFile,
     replace: getReplace(),
     transforms: getTransforms(),
+    eol: getEol(),
   };
 }
 
@@ -100,4 +102,24 @@ function validateTransforms(transformNames) {
       throw `Unknown transform "${name}".`;
     }
   });
+}
+
+function getEol() {
+  if (!program.eol) {
+    return;
+  }
+
+  switch (program.eol.toLowerCase()) {
+  case 'cr':
+    return '\r';
+
+  case 'lf':
+    return '\n';
+
+  case 'crlf':
+    return '\r\n';
+
+  default:
+    throw 'Invalid line terminator. Expected cr, lf or crlf';
+  }
 }


### PR DESCRIPTION
Allows the user to supply `--eol` on the CLI to set a line terminator.
cr, lf and crlf are supported. The transformer will default to using the OS default line terminator.
Fixes #177
Closes #172